### PR TITLE
Add GC links

### DIFF
--- a/src/ctypes_helpers.ml
+++ b/src/ctypes_helpers.ml
@@ -198,3 +198,8 @@ let with_out_fmt filename f =
   in
   finally ();
   result
+
+let add_gc_link ~from ~to_ =
+  let r = ref (Some (Obj.repr to_)) in
+  let finaliser _ = r := None in
+  Gc.finalise finaliser from

--- a/src/ctypes_helpers.mli
+++ b/src/ctypes_helpers.mli
@@ -9,6 +9,27 @@ val safe_deref : 'a Ctypes.ptr -> 'a
 
 type ulong = Unsigned.ULong.t
 
+module Reachable_ptr : sig
+  (** Pointers with a GC link from the structure they are in.
+      These are like [Ctypes.ptr] except that [setf] will add a link (through a
+      finalizer) from the structure to the pointer to prevent its early
+      collection. *)
+
+  type 'a t
+
+  (** Ctypes type. *)
+  val typ : 'a Ctypes_static.typ -> 'a t Ctypes_static.typ
+
+  (** Combine [Ctypes.setf] and [create].
+      The parent object is set to the structured value. *)
+  val setf : ('b, 'c) Ctypes.structured ->
+    ('a t, ('b, 'c) Ctypes.structured) Ctypes.field -> 'a Ctypes.ptr -> unit
+
+  (** Call [Ctypes.getf] and unwrap the result. *)
+  val getf : ('b, 'c) Ctypes.structured ->
+    ('a t, ('b, 'c) Ctypes.structured) Ctypes.field -> 'a Ctypes.ptr
+end
+
 (******************************************************************************)
 (*                    String conversions to/from C pointers                   *)
 (******************************************************************************)
@@ -49,7 +70,7 @@ val make_string :
   string ->
   'a Ctypes.structure ->
   (Unsigned.ULong.t, 'a Ctypes.structure) Ctypes.field ->
-  ('b Ctypes.ptr, 'a Ctypes.structure) Ctypes.field -> unit
+  ('b Reachable_ptr.t, 'a Ctypes.structure) Ctypes.field -> unit
 
 (**
  * Read an OCaml string from a Ctypes struct.
@@ -59,7 +80,7 @@ val make_string :
 val view_string :
   'b Ctypes.structure ->
   (ulong, 'b Ctypes.structure) Ctypes.field ->
-  ('a Ctypes.ptr, 'b Ctypes.structure) Ctypes.field -> string
+  ('a Reachable_ptr.t, 'b Ctypes.structure) Ctypes.field -> string
 
 (**
  * Copy a string option to a pointer + length.
@@ -70,7 +91,7 @@ val make_string_option :
   string option ->
   ('a, [ `Struct ]) Ctypes.structured ->
   (Unsigned.ULong.t, ('a, [ `Struct ]) Ctypes.structured) Ctypes.field ->
-  ('b Ctypes.ptr, ('a, [ `Struct ]) Ctypes.structured) Ctypes.field -> unit
+  ('b Reachable_ptr.t, ('a, [ `Struct ]) Ctypes.structured) Ctypes.field -> unit
 
 (**
  * Make a string option out of a pointer + length.
@@ -80,7 +101,7 @@ val make_string_option :
 val view_string_option :
   ('a, [ `Struct ]) Ctypes.structured ->
   (ulong, 'a Ctypes.structure) Ctypes.field ->
-  ('b Ctypes.ptr, ('a, [ `Struct ]) Ctypes.structured) Ctypes.field ->
+  ('b Reachable_ptr.t, ('a, [ `Struct ]) Ctypes.structured) Ctypes.field ->
   string option
 
 exception Buffer_overflow
@@ -100,7 +121,3 @@ val smart_field : 't Ctypes.typ -> string -> 'a Ctypes.typ -> ('a, (('s, [<`Stru
 
 (** Open a file for writing and returns a formatter to it. *)
 val with_out_fmt : string -> (Format.formatter -> 'a) -> 'a
-
-(** Add a GC dependency from one object to another:
-    while [from] is reachable, [to_] is reachable too. *)
-val add_gc_link : from:'a -> to_:'b -> unit

--- a/src/ctypes_helpers.mli
+++ b/src/ctypes_helpers.mli
@@ -100,3 +100,7 @@ val smart_field : 't Ctypes.typ -> string -> 'a Ctypes.typ -> ('a, (('s, [<`Stru
 
 (** Open a file for writing and returns a formatter to it. *)
 val with_out_fmt : string -> (Format.formatter -> 'a) -> 'a
+
+(** Add a GC dependency from one object to another:
+    while [from] is reachable, [to_] is reachable too. *)
+val add_gc_link : from:'a -> to_:'b -> unit

--- a/src/pkcs11_CBC_ENCRYPT_DATA_PARAMS.ml
+++ b/src/pkcs11_CBC_ENCRYPT_DATA_PARAMS.ml
@@ -19,7 +19,7 @@ struct
 
   let (-:) typ label = smart_field t label typ
   let iv = array iv_size Pkcs11_CK_BYTE.typ -: "iv"
-  let pData = ptr Pkcs11_CK_BYTE.typ -: "pData"
+  let pData = Reachable_ptr.typ Pkcs11_CK_BYTE.typ -: "pData"
   let length = ulong -: "length"
   let () = seal t
 
@@ -47,7 +47,7 @@ struct
       data =
         string_from_ptr
           ~length:(getf t length |> Unsigned.ULong.to_int)
-          (getf t pData);
+          (Reachable_ptr.getf t pData);
     }
 
   let compare a b =

--- a/src/pkcs11_CK_ATTRIBUTE.ml
+++ b/src/pkcs11_CK_ATTRIBUTE.ml
@@ -58,7 +58,9 @@ let create attribute_type : t =
     for the value. *)
 let allocate (t: t) : unit =
   let count = Unsigned.ULong.to_int  (getf t ulValueLen) in
-  setf t pValue (to_voidp (allocate_n (char) ~count));
+  let ptr = allocate_n (char) ~count in
+  add_gc_link ~from:t ~to_:ptr;
+  setf t pValue (to_voidp ptr);
   ()
 
 let get_type t =
@@ -94,8 +96,9 @@ let byte attribute_type byte : t =
   a
 
 let ulong attribute_type ulong : t =
-  let  a= Ctypes.make ck_attribute in
+  let a = Ctypes.make ck_attribute in
   let ulong = Ctypes.allocate Ctypes.ulong ulong in
+  add_gc_link ~from:a ~to_:ulong;
   setf a _type attribute_type;
   setf a pValue (to_voidp ulong);
   setf a ulValueLen (Unsigned.ULong.of_int (sizeof Ctypes.ulong));
@@ -104,6 +107,7 @@ let ulong attribute_type ulong : t =
 let string attribute_type string : t =
   let a = Ctypes.make ck_attribute in
   let s = ptr_from_string string in
+  add_gc_link ~from:a ~to_:s;
   setf a _type attribute_type;
   setf a pValue (to_voidp s);
   setf a ulValueLen (Unsigned.ULong.of_int (String.length string));

--- a/src/pkcs11_CK_ATTRIBUTE.mli
+++ b/src/pkcs11_CK_ATTRIBUTE.mli
@@ -37,4 +37,4 @@ val to_string_pair: 'a u -> string * string
 val ck_attribute : t Ctypes.typ
 
 val ulValueLen : (Unsigned.ulong, t) Ctypes.field
-val pValue : (unit Ctypes_static.ptr, t) Ctypes.field
+val pValue : (unit Ctypes_helpers.Reachable_ptr.t, t) Ctypes.field

--- a/src/pkcs11_CK_ATTRIBUTE_SET.ml
+++ b/src/pkcs11_CK_ATTRIBUTE_SET.ml
@@ -14,7 +14,7 @@ let _setter_ : (unit Ctypes.ptr -> 'a -> unit) -> Unsigned.ULong.t -> t -> 'a ->
         if getf t ulValueLen >= size
         then
           begin
-            ff (getf t pValue) elem;
+            ff (Ctypes_helpers.Reachable_ptr.getf t pValue) elem;
             setf t ulValueLen size;
             Pkcs11_CK_RV.CKR_OK
           end

--- a/src/pkcs11_CK_ECDH1_DERIVE_PARAMS.ml
+++ b/src/pkcs11_CK_ECDH1_DERIVE_PARAMS.ml
@@ -8,9 +8,9 @@ let t : t typ = structure "CK_ECDH1_DERIVE_PARAMS"
 let (-:) typ label = smart_field t label typ
 let kdf = Pkcs11_CK_EC_KDF_TYPE.t -: "kdf"
 let ulSharedDataLen = ulong -: "ulSharedDataLen"
-let pSharedData = ptr Pkcs11_CK_BYTE.typ -: "pSharedData"
+let pSharedData = Reachable_ptr.typ Pkcs11_CK_BYTE.typ -: "pSharedData"
 let ulPublicDataLen = ulong -: "ulPublicDataLen"
-let pPublicData = ptr Pkcs11_CK_BYTE.typ -: "pPublicData"
+let pPublicData = Reachable_ptr.typ Pkcs11_CK_BYTE.typ -: "pPublicData"
 let () = seal t
 
 type u =

--- a/src/pkcs11_CK_ECMQV_DERIVE_PARAMS.ml
+++ b/src/pkcs11_CK_ECMQV_DERIVE_PARAMS.ml
@@ -8,13 +8,13 @@ let t : t typ = structure "CK_ECMQV_DERIVE_PARAMS"
 let (-:) typ label = smart_field t label typ
 let kdf              = Pkcs11_CK_EC_KDF_TYPE.t -: "kdf"
 let ulSharedDataLen  = ulong            -: "ulSharedDataLen"
-let pSharedData      = ptr char         -: "pSharedData"
+let pSharedData      = Reachable_ptr.typ char -: "pSharedData"
 let ulPublicDataLen  = ulong            -: "ulPublicDataLen"
-let pPublicData      = ptr char         -: "pPublicData"
+let pPublicData      = Reachable_ptr.typ char         -: "pPublicData"
 let ulPrivateDataLen = ulong            -: "ulPrivateDataLen"
 let hPrivateData     = Pkcs11_CK_OBJECT_HANDLE.typ -: "hPrivateData"
 let ulPublicDataLen2 = ulong            -: "ulPublicDataLen2"
-let pPublicData2     = ptr char         -: "pPublicData2"
+let pPublicData2     = Reachable_ptr.typ char -: "pPublicData2"
 let publicKey        = Pkcs11_CK_OBJECT_HANDLE.typ -: "publicKey"
 let () = seal t
 

--- a/src/pkcs11_CK_KEY_DERIVATION_STRING_DATA.ml
+++ b/src/pkcs11_CK_KEY_DERIVATION_STRING_DATA.ml
@@ -6,7 +6,7 @@ type t = _t structure
 let t: t typ = structure "CK_KEY_DERIVATION_STRING_DATA"
 
 let (-:) typ label = smart_field t label typ
-let pData = ptr Pkcs11_CK_BYTE.typ -: "pData"
+let pData = Reachable_ptr.typ Pkcs11_CK_BYTE.typ -: "pData"
 let ulLen = ulong -: "ulLen"
 let () = seal t
 
@@ -15,11 +15,11 @@ type u = string
 let make (u: u): t =
   let t = make t in
   let data = ptr_from_string u in
-  setf t pData data;
+  Reachable_ptr.setf t pData data;
   setf t ulLen (Unsigned.ULong.of_int @@ String.length u);
   t
 
 let view (t: t): u =
   string_from_ptr
     ~length:(getf t ulLen |> Unsigned.ULong.to_int)
-    (getf t pData)
+    (Reachable_ptr.getf t pData)

--- a/src/pkcs11_CK_MECHANISM.ml
+++ b/src/pkcs11_CK_MECHANISM.ml
@@ -81,6 +81,7 @@ let make: u -> t =
     let m = make ck_mechanism in
     setf m mechanism ckm;
     setf m parameter param;
+    add_gc_link ~from:m ~to_:param;
     setf m parameter_len param_len;
     m
   in
@@ -92,12 +93,14 @@ let make: u -> t =
   let pss ckm params =
     struct_ ckm params Pkcs11_CK_RSA_PKCS_PSS_PARAMS.t Pkcs11_CK_RSA_PKCS_PSS_PARAMS.make
   in
-  let data ckm params =
+  let string ckm param =
+    let params = Pkcs11_data.of_string param in
     let char_ptr = Pkcs11_data.get_content params in
     let param_len = Pkcs11_data.get_length params in
-    make ckm (to_voidp char_ptr) param_len
+    let mech = make ckm (to_voidp char_ptr) param_len in
+    add_gc_link ~from:mech ~to_:char_ptr;
+    mech
   in
-  let string ckm param = data ckm (Pkcs11_data.of_string param) in
   let derivation_string ckm param =
     struct_ ckm param
       Pkcs11_CK_KEY_DERIVATION_STRING_DATA.t Pkcs11_CK_KEY_DERIVATION_STRING_DATA.make

--- a/src/pkcs11_CK_PKCS5_PBKD2_PARAMS.ml
+++ b/src/pkcs11_CK_PKCS5_PBKD2_PARAMS.ml
@@ -7,14 +7,14 @@ let t: t typ = structure "CK_PKCS5_PBKD2_DATA_PARAMS"
 
 let (-:) typ label = smart_field t label typ
 let saltSource = Pkcs11_CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE.typ -: "saltSource"
-let pSaltSourceData = ptr void -: "pSaltSourceData"
+let pSaltSourceData = Reachable_ptr.typ void -: "pSaltSourceData"
 let ulSaltSourceDataLen = ulong -: "ulSaltSourceDataLen"
 let iterations = ulong -: "iterations"
 let prf = Pkcs11_CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE.typ -: "prf"
-let pPrfData = ptr void -: "pPrfData"
+let pPrfData = Reachable_ptr.typ void -: "pPrfData"
 let ulPrfDataLen = ulong -: "ulPrfDataLen"
-let pPassword = ptr char -: "pPassword"
-let pPasswordLen = ptr ulong -: "pPasswordLen"
+let pPassword = Reachable_ptr.typ char -: "pPassword"
+let pPasswordLen = Reachable_ptr.typ ulong -: "pPasswordLen"
 let () = seal t
 
 type u =
@@ -37,8 +37,8 @@ let make (u: u): t =
   setf t iterations (Unsigned.ULong.of_int u.iterations);
   setf t prf @@ Pkcs11_CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE.make u.prf;
   make_string_option u.prfData t ulPrfDataLen pPrfData;
-  setf t pPassword @@ ptr_from_string u.password;
-  setf t pPasswordLen @@ Ctypes.allocate ulong (
+  Reachable_ptr.setf t pPassword @@ ptr_from_string u.password;
+  Reachable_ptr.setf t pPasswordLen @@ Ctypes.allocate ulong (
     Unsigned.ULong.of_int @@ String.length u.password
   );
   t
@@ -50,8 +50,8 @@ let view (t: t): u =
   let prf = Pkcs11_CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE.view @@ getf t prf in
   let prfData = view_string_option t ulPrfDataLen pPrfData in
   let password =
-    let pPassword = getf t pPassword in
-    let pPasswordLen = getf t pPasswordLen in
+    let pPassword = Reachable_ptr.getf t pPassword in
+    let pPasswordLen = Reachable_ptr.getf t pPasswordLen in
     let pPasswordLen = !@ pPasswordLen in
     string_from_ptr
       ~length: (Unsigned.ULong.to_int pPasswordLen)

--- a/src/pkcs11_CK_RSA_PKCS_OAEP_PARAMS.ml
+++ b/src/pkcs11_CK_RSA_PKCS_OAEP_PARAMS.ml
@@ -13,7 +13,7 @@ let (-:) ty label = smart_field t label ty
 let hashAlg = Pkcs11_CK_MECHANISM_TYPE.typ -: "hashAlg"
 let mgf = Pkcs11_CK_RSA_PKCS_MGF_TYPE.typ -: "mgf"
 let source  = source_type -: "source"
-let pSourceData = ptr void -: "pSourceData"
+let pSourceData = Reachable_ptr.typ void -: "pSourceData"
 let pSourceDataLen = ulong -: "pSourceDataLen"
 let () = seal t
 


### PR DESCRIPTION
This fixes the use after free problems discovered in #10 by adding an explicit GC link (through a finalizer). This is a two step solution: a low level one just adds the calls by hand, and a second commit wraps this operation in a (partially) type-safe way.