### PR TITLE
Remove deprecated operator aliases

### DIFF
--- a/src/p11.ml
+++ b/src/p11.ml
@@ -2316,7 +2316,6 @@ struct
       template
     else
       attribute :: template
-  let (^::^) = set_attribute
 
   let remove_attribute attribute template =
     List.filter (fun x -> not (Attribute.equal_pack x attribute)) template
@@ -2331,11 +2330,9 @@ struct
 
   let union template1 template2 =
     List.fold_left
-      (fun template attribute -> attribute ^::^ template)
+      (fun template attribute -> set_attribute attribute template)
       template2
       (List.rev template1)
-
-  let (^@^) = union
 
   let only_attribute_types types template =
     List.fold_left (fun template attribute ->
@@ -2366,8 +2363,6 @@ struct
             end
     in
     aux types []
-
-  let (^-^) = except_attribute_types
 
   let correspond ~source ~tested =
     (* For all the elements of source, check if an element in tested

--- a/src/p11.mli
+++ b/src/p11.mli
@@ -1126,18 +1126,10 @@ sig
   (** Iterate one of the above operation. Same as List.fold_right*)
   val fold: ('a -> t -> t) -> 'a list -> t -> t
 
-  (** same as [set_attribute]  *)
-  val (^::^) : Attribute.pack -> t -> t
-      [@@deprecated "Please use set_attribute instead."]
-
   (** [union template1 template2] concatenates the templates. If an
       attribute is present in both [template1] and [template2], the
       value in [template1] is kept. *)
   val union : t -> t -> t
-
-  (** Same as [union] *)
-  val (^@^) : t -> t -> t
-      [@@deprecated "Please use union instead."]
 
   (** [only_attribute_types attr_types template] keeps only the
       attributes in [template] that are present in [attr_types]. *)
@@ -1151,10 +1143,6 @@ sig
       attribute type in the list l in [template]. Return [None] if one
       or several attribute types cannot be found in [template]. *)
   val find_attribute_types : Attribute_type.pack list -> t -> t option
-
-  (** Same as [except_attribute_types]. *)
-  val (^-^) : Attribute_type.pack list -> t -> t
-      [@@deprecated "Please use except_attribute_types instead."]
 
   (** [correspond source tested] check if [tested] match
       [source].


### PR DESCRIPTION
These have been deprecated since virtually forever (pre-0.1.0).