### PR TITLE
Remove "not implemented" attributes

### DIFF
--- a/src/p11.ml
+++ b/src/p11.ml
@@ -1601,21 +1601,8 @@ struct
     | CKA_TOKEN : bool t
     | CKA_PRIVATE : bool t
     | CKA_LABEL : string t
-    | CKA_APPLICATION : not_implemented t
     | CKA_VALUE : string t
-    | CKA_OBJECT_ID : not_implemented t
-    | CKA_CERTIFICATE_TYPE : not_implemented t
-    | CKA_ISSUER : not_implemented t
-    | CKA_SERIAL_NUMBER : not_implemented t
-    | CKA_AC_ISSUER : not_implemented t
-    | CKA_OWNER : not_implemented t
-    | CKA_ATTR_TYPES : not_implemented t
     | CKA_TRUSTED : bool t
-    | CKA_CERTIFICATE_CATEGORY : not_implemented t
-    | CKA_JAVA_MIDP_SECURITY_DOMAIN : not_implemented t
-    | CKA_URL : not_implemented t
-    | CKA_HASH_OF_SUBJECT_PUBLIC_KEY : not_implemented t
-    | CKA_HASH_OF_ISSUER_PUBLIC_KEY : not_implemented t
     | CKA_CHECK_VALUE : not_implemented t
     | CKA_KEY_TYPE : Pkcs11.CK_KEY_TYPE.u t
     | CKA_SUBJECT : string t
@@ -1643,11 +1630,8 @@ struct
     | CKA_COEFFICIENT : Pkcs11.CK_BIGINT.t t
     | CKA_PRIME : Pkcs11.CK_BIGINT.t t
     | CKA_SUBPRIME : Pkcs11.CK_BIGINT.t t
-    | CKA_BASE : not_implemented t
     | CKA_PRIME_BITS : Pkcs11.CK_ULONG.t t
     | CKA_SUBPRIME_BITS : Pkcs11.CK_ULONG.t t
-    (* | CKA_SUB_PRIME_BITS : not_implemented t *)
-    | CKA_VALUE_BITS : not_implemented t
     | CKA_VALUE_LEN : Pkcs11.CK_ULONG.t t
     | CKA_EXTRACTABLE : bool t
     | CKA_LOCAL : bool t
@@ -1658,45 +1642,11 @@ struct
     (* | CKA_ECDSA_PARAMS : string t *)
     | CKA_EC_PARAMS : Key_parsers.Asn1.EC.Params.t t
     | CKA_EC_POINT : Key_parsers.Asn1.EC.point t
-    | CKA_SECONDARY_AUTH : not_implemented t
-    | CKA_AUTH_PIN_FLAGS : not_implemented t
     | CKA_ALWAYS_AUTHENTICATE : bool t
     | CKA_WRAP_WITH_TRUSTED : bool t
     | CKA_WRAP_TEMPLATE : not_implemented t
     | CKA_UNWRAP_TEMPLATE : not_implemented t
-    | CKA_OTP_FORMAT : not_implemented t
-    | CKA_OTP_LENGTH : not_implemented t
-    | CKA_OTP_TIME_INTERVAL : not_implemented t
-    | CKA_OTP_USER_FRIENDLY_MODE : not_implemented t
-    | CKA_OTP_CHALLENGE_REQUIREMENT : not_implemented t
-    | CKA_OTP_TIME_REQUIREMENT : not_implemented t
-    | CKA_OTP_COUNTER_REQUIREMENT : not_implemented t
-    | CKA_OTP_PIN_REQUIREMENT : not_implemented t
-    | CKA_OTP_COUNTER : not_implemented t
-    | CKA_OTP_TIME : not_implemented t
-    | CKA_OTP_USER_IDENTIFIER : not_implemented t
-    | CKA_OTP_SERVICE_IDENTIFIER : not_implemented t
-    | CKA_OTP_SERVICE_LOGO : not_implemented t
-    | CKA_OTP_SERVICE_LOGO_TYPE : not_implemented t
-    | CKA_HW_FEATURE_TYPE : not_implemented t
-    | CKA_RESET_ON_INIT : not_implemented t
-    | CKA_HAS_RESET : not_implemented t
-    | CKA_PIXEL_X : not_implemented t
-    | CKA_PIXEL_Y : not_implemented t
-    | CKA_RESOLUTION : not_implemented t
-    | CKA_CHAR_ROWS : not_implemented t
-    | CKA_CHAR_COLUMNS : not_implemented t
-    | CKA_COLOR : not_implemented t
-    | CKA_BITS_PER_PIXEL : not_implemented t
-    | CKA_CHAR_SETS : not_implemented t
-    | CKA_ENCODING_METHODS : not_implemented t
-    | CKA_MIME_TYPES : not_implemented t
-    | CKA_MECHANISM_TYPE : not_implemented t
-    | CKA_REQUIRED_CMS_ATTRIBUTES : not_implemented t
-    | CKA_DEFAULT_CMS_ATTRIBUTES : not_implemented t
-    | CKA_SUPPORTED_CMS_ATTRIBUTES : not_implemented t
     | CKA_ALLOWED_MECHANISMS : not_implemented t
-    | CKA_VENDOR_DEFINED : not_implemented t
     | CKA_CS_UNKNOWN: Unsigned.ULong.t -> not_implemented t
 
   type pack = Pkcs11.CK_ATTRIBUTE_TYPE.pack = Pack : 'a t -> pack
@@ -1874,8 +1824,6 @@ struct
           p_mechanism_type "CKA_KEY_GEN_MECHANISM" param
       | CKA_MODIFIABLE, param ->
           p_bool "CKA_MODIFIABLE" param
-      (* | CKA_ECDSA_PARAMS, param -> *)
-      (*     p_data "CKA_ECDSA_PARAMS" param *)
       | CKA_EC_PARAMS, param ->
           p_ec_params "CKA_EC_PARAMS" param
       | CKA_EC_POINT, param ->
@@ -1884,122 +1832,22 @@ struct
           p_bool "CKA_ALWAYS_AUTHENTICATE" param
       | CKA_WRAP_WITH_TRUSTED, param ->
           p_bool "CKA_WRAP_WITH_TRUSTED" param
-      | CKA_APPLICATION, NOT_IMPLEMENTED param ->
-          p_data "CKA_APPLICATION" param
-      | CKA_OBJECT_ID, NOT_IMPLEMENTED param ->
-          p_data "CKA_OBJECT_ID" param
-      | CKA_CERTIFICATE_TYPE, NOT_IMPLEMENTED param ->
-          p_data "CKA_CERTIFICATE_TYPE" param
-      | CKA_ISSUER, NOT_IMPLEMENTED param ->
-          p_data "CKA_ISSUER" param
-      | CKA_SERIAL_NUMBER, NOT_IMPLEMENTED param ->
-          p_data "CKA_SERIAL_NUMBER" param
-      | CKA_AC_ISSUER, NOT_IMPLEMENTED param ->
-          p_data "CKA_AC_ISSUER" param
-      | CKA_OWNER, NOT_IMPLEMENTED param ->
-          p_data "CKA_OWNER" param
-      | CKA_ATTR_TYPES, NOT_IMPLEMENTED param ->
-          p_data "CKA_ATTR_TYPES" param
-      | CKA_CERTIFICATE_CATEGORY, NOT_IMPLEMENTED param ->
-          p_data "CKA_CERTIFICATE_CATEGORY" param
-      | CKA_JAVA_MIDP_SECURITY_DOMAIN, NOT_IMPLEMENTED param ->
-          p_data "CKA_JAVA_MIDP_SECURITY_DOMAIN" param
-      | CKA_URL, NOT_IMPLEMENTED param ->
-          p_data "CKA_URL" param
-      | CKA_HASH_OF_SUBJECT_PUBLIC_KEY, NOT_IMPLEMENTED param ->
-          p_data "CKA_HASH_OF_SUBJECT_PUBLIC_KEY" param
-      | CKA_HASH_OF_ISSUER_PUBLIC_KEY, NOT_IMPLEMENTED param ->
-          p_data "CKA_HASH_OF_ISSUER_PUBLIC_KEY" param
       | CKA_CHECK_VALUE, NOT_IMPLEMENTED param ->
           p_data "CKA_CHECK_VALUE" param
       | CKA_START_DATE, NOT_IMPLEMENTED param ->
           p_data "CKA_START_DATE" param
       | CKA_END_DATE, NOT_IMPLEMENTED param ->
           p_data "CKA_END_DATE" param
-      | CKA_BASE, NOT_IMPLEMENTED param ->
-          p_data "CKA_BASE" param
       | CKA_PRIME_BITS, param ->
           p_ulong "CKA_PRIME_BITS" param
       | CKA_SUBPRIME_BITS, param ->
           p_ulong "CKA_SUBPRIME_BITS" param
-      (* | CKA_SUB_PRIME_BITS, NOT_IMPLEMENTED param -> *)
-      (*     p_data "CKA_SUB_PRIME_BITS" param *)
-      | CKA_VALUE_BITS, NOT_IMPLEMENTED param ->
-          p_data "CKA_VALUE_BITS" param
-      | CKA_SECONDARY_AUTH, NOT_IMPLEMENTED param ->
-          p_data "CKA_SECONDARY_AUTH" param
-      | CKA_AUTH_PIN_FLAGS, NOT_IMPLEMENTED param ->
-          p_data "CKA_AUTH_PIN_FLAGS" param
       | CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED param ->
           p_data "CKA_WRAP_TEMPLATE" param
       | CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED param ->
           p_data "CKA_UNWRAP_TEMPLATE" param
-      | CKA_OTP_FORMAT, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_FORMAT" param
-      | CKA_OTP_LENGTH, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_LENGTH" param
-      | CKA_OTP_TIME_INTERVAL, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_TIME_INTERVAL" param
-      | CKA_OTP_USER_FRIENDLY_MODE, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_USER_FRIENDLY_MODE" param
-      | CKA_OTP_CHALLENGE_REQUIREMENT, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_CHALLENGE_REQUIREMENT" param
-      | CKA_OTP_TIME_REQUIREMENT, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_TIME_REQUIREMENT" param
-      | CKA_OTP_COUNTER_REQUIREMENT, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_COUNTER_REQUIREMENT" param
-      | CKA_OTP_PIN_REQUIREMENT, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_PIN_REQUIREMENT" param
-      | CKA_OTP_COUNTER, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_COUNTER" param
-      | CKA_OTP_TIME, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_TIME" param
-      | CKA_OTP_USER_IDENTIFIER, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_USER_IDENTIFIER" param
-      | CKA_OTP_SERVICE_IDENTIFIER, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_SERVICE_IDENTIFIER" param
-      | CKA_OTP_SERVICE_LOGO, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_SERVICE_LOGO" param
-      | CKA_OTP_SERVICE_LOGO_TYPE, NOT_IMPLEMENTED param ->
-          p_data "CKA_OTP_SERVICE_LOGO_TYPE" param
-      | CKA_HW_FEATURE_TYPE, NOT_IMPLEMENTED param ->
-          p_data "CKA_HW_FEATURE_TYPE" param
-      | CKA_RESET_ON_INIT, NOT_IMPLEMENTED param ->
-          p_data "CKA_RESET_ON_INIT" param
-      | CKA_HAS_RESET, NOT_IMPLEMENTED param ->
-          p_data "CKA_HAS_RESET" param
-      | CKA_PIXEL_X, NOT_IMPLEMENTED param ->
-          p_data "CKA_PIXEL_X" param
-      | CKA_PIXEL_Y, NOT_IMPLEMENTED param ->
-          p_data "CKA_PIXEL_Y" param
-      | CKA_RESOLUTION, NOT_IMPLEMENTED param ->
-          p_data "CKA_RESOLUTION" param
-      | CKA_CHAR_ROWS, NOT_IMPLEMENTED param ->
-          p_data "CKA_CHAR_ROWS" param
-      | CKA_CHAR_COLUMNS, NOT_IMPLEMENTED param ->
-          p_data "CKA_CHAR_COLUMNS" param
-      | CKA_COLOR, NOT_IMPLEMENTED param ->
-          p_data "CKA_COLOR" param
-      | CKA_BITS_PER_PIXEL, NOT_IMPLEMENTED param ->
-          p_data "CKA_BITS_PER_PIXEL" param
-      | CKA_CHAR_SETS, NOT_IMPLEMENTED param ->
-          p_data "CKA_CHAR_SETS" param
-      | CKA_ENCODING_METHODS, NOT_IMPLEMENTED param ->
-          p_data "CKA_ENCODING_METHODS" param
-      | CKA_MIME_TYPES, NOT_IMPLEMENTED param ->
-          p_data "CKA_MIME_TYPES" param
-      | CKA_MECHANISM_TYPE, NOT_IMPLEMENTED param ->
-          p_data "CKA_MECHANISM_TYPE" param
-      | CKA_REQUIRED_CMS_ATTRIBUTES, NOT_IMPLEMENTED param ->
-          p_data "CKA_REQUIRED_CMS_ATTRIBUTES" param
-      | CKA_DEFAULT_CMS_ATTRIBUTES, NOT_IMPLEMENTED param ->
-          p_data "CKA_DEFAULT_CMS_ATTRIBUTES" param
-      | CKA_SUPPORTED_CMS_ATTRIBUTES, NOT_IMPLEMENTED param ->
-          p_data "CKA_SUPPORTED_CMS_ATTRIBUTES" param
       | CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED param ->
           p_data "CKA_ALLOWED_MECHANISMS" param
-      | CKA_VENDOR_DEFINED, NOT_IMPLEMENTED param ->
-          p_data "CKA_VENDOR_DEFINED" param
       | CKA_CS_UNKNOWN ul, NOT_IMPLEMENTED param ->
           p_data (Unsigned.ULong.to_string ul) param
 
@@ -2110,8 +1958,6 @@ struct
             p_mechanism_type CKA_KEY_GEN_MECHANISM
         | "CKA_MODIFIABLE" ->
             p_bool CKA_MODIFIABLE
-        (* | "CKA_ECDSA_PARAMS" -> *)
-        (*     p_data CKA_ECDSA_PARAMS *)
         | "CKA_EC_PARAMS" ->
             p_ec_params CKA_EC_PARAMS
         | "CKA_EC_POINT" ->
@@ -2120,120 +1966,22 @@ struct
             p_bool CKA_ALWAYS_AUTHENTICATE
         | "CKA_WRAP_WITH_TRUSTED" ->
             p_bool CKA_WRAP_WITH_TRUSTED
-        | "CKA_APPLICATION" ->
-            p_not_implemented CKA_APPLICATION
-        | "CKA_OBJECT_ID" ->
-            p_not_implemented CKA_OBJECT_ID
-        | "CKA_CERTIFICATE_TYPE" ->
-            p_not_implemented CKA_CERTIFICATE_TYPE
-        | "CKA_ISSUER" ->
-            p_not_implemented CKA_ISSUER
-        | "CKA_SERIAL_NUMBER" ->
-            p_not_implemented CKA_SERIAL_NUMBER
-        | "CKA_AC_ISSUER" ->
-            p_not_implemented CKA_AC_ISSUER
-        | "CKA_OWNER" ->
-            p_not_implemented CKA_OWNER
-        | "CKA_ATTR_TYPES" ->
-            p_not_implemented CKA_ATTR_TYPES
-        | "CKA_CERTIFICATE_CATEGORY" ->
-            p_not_implemented CKA_CERTIFICATE_CATEGORY
-        | "CKA_JAVA_MIDP_SECURITY_DOMAIN" ->
-            p_not_implemented CKA_JAVA_MIDP_SECURITY_DOMAIN
-        | "CKA_URL" ->
-            p_not_implemented CKA_URL
-        | "CKA_HASH_OF_SUBJECT_PUBLIC_KEY" ->
-            p_not_implemented CKA_HASH_OF_SUBJECT_PUBLIC_KEY
-        | "CKA_HASH_OF_ISSUER_PUBLIC_KEY" ->
-            p_not_implemented CKA_HASH_OF_ISSUER_PUBLIC_KEY
         | "CKA_CHECK_VALUE" ->
             p_not_implemented CKA_CHECK_VALUE
         | "CKA_START_DATE" ->
             p_not_implemented CKA_START_DATE
         | "CKA_END_DATE" ->
             p_not_implemented CKA_END_DATE
-        | "CKA_BASE" ->
-            p_not_implemented CKA_BASE
         | "CKA_PRIME_BITS" ->
             p_ulong CKA_PRIME_BITS
         | "CKA_SUBPRIME_BITS" ->
             p_ulong CKA_SUBPRIME_BITS
-        | "CKA_VALUE_BITS" ->
-            p_not_implemented CKA_VALUE_BITS
-        | "CKA_SECONDARY_AUTH" ->
-            p_not_implemented CKA_SECONDARY_AUTH
-        | "CKA_AUTH_PIN_FLAGS" ->
-            p_not_implemented CKA_AUTH_PIN_FLAGS
         | "CKA_WRAP_TEMPLATE" ->
             p_not_implemented CKA_WRAP_TEMPLATE
         | "CKA_UNWRAP_TEMPLATE" ->
             p_not_implemented CKA_UNWRAP_TEMPLATE
-        | "CKA_OTP_FORMAT" ->
-            p_not_implemented CKA_OTP_FORMAT
-        | "CKA_OTP_LENGTH" ->
-            p_not_implemented CKA_OTP_LENGTH
-        | "CKA_OTP_TIME_INTERVAL" ->
-            p_not_implemented CKA_OTP_TIME_INTERVAL
-        | "CKA_OTP_USER_FRIENDLY_MODE" ->
-            p_not_implemented CKA_OTP_USER_FRIENDLY_MODE
-        | "CKA_OTP_CHALLENGE_REQUIREMENT" ->
-            p_not_implemented CKA_OTP_CHALLENGE_REQUIREMENT
-        | "CKA_OTP_TIME_REQUIREMENT" ->
-            p_not_implemented CKA_OTP_TIME_REQUIREMENT
-        | "CKA_OTP_COUNTER_REQUIREMENT" ->
-            p_not_implemented CKA_OTP_COUNTER_REQUIREMENT
-        | "CKA_OTP_PIN_REQUIREMENT" ->
-            p_not_implemented CKA_OTP_PIN_REQUIREMENT
-        | "CKA_OTP_COUNTER" ->
-            p_not_implemented CKA_OTP_COUNTER
-        | "CKA_OTP_TIME" ->
-            p_not_implemented CKA_OTP_TIME
-        | "CKA_OTP_USER_IDENTIFIER" ->
-            p_not_implemented CKA_OTP_USER_IDENTIFIER
-        | "CKA_OTP_SERVICE_IDENTIFIER" ->
-            p_not_implemented CKA_OTP_SERVICE_IDENTIFIER
-        | "CKA_OTP_SERVICE_LOGO" ->
-            p_not_implemented CKA_OTP_SERVICE_LOGO
-        | "CKA_OTP_SERVICE_LOGO_TYPE" ->
-            p_not_implemented CKA_OTP_SERVICE_LOGO_TYPE
-        | "CKA_HW_FEATURE_TYPE" ->
-            p_not_implemented CKA_HW_FEATURE_TYPE
-        | "CKA_RESET_ON_INIT" ->
-            p_not_implemented CKA_RESET_ON_INIT
-        | "CKA_HAS_RESET" ->
-            p_not_implemented CKA_HAS_RESET
-        | "CKA_PIXEL_X" ->
-            p_not_implemented CKA_PIXEL_X
-        | "CKA_PIXEL_Y" ->
-            p_not_implemented CKA_PIXEL_Y
-        | "CKA_RESOLUTION" ->
-            p_not_implemented CKA_RESOLUTION
-        | "CKA_CHAR_ROWS" ->
-            p_not_implemented CKA_CHAR_ROWS
-        | "CKA_CHAR_COLUMNS" ->
-            p_not_implemented CKA_CHAR_COLUMNS
-        | "CKA_COLOR" ->
-            p_not_implemented CKA_COLOR
-        | "CKA_BITS_PER_PIXEL" ->
-            p_not_implemented CKA_BITS_PER_PIXEL
-        | "CKA_CHAR_SETS" ->
-            p_not_implemented CKA_CHAR_SETS
-        | "CKA_ENCODING_METHODS" ->
-            p_not_implemented CKA_ENCODING_METHODS
-        | "CKA_MIME_TYPES" ->
-            p_not_implemented CKA_MIME_TYPES
-        | "CKA_MECHANISM_TYPE" ->
-            p_not_implemented CKA_MECHANISM_TYPE
-        | "CKA_REQUIRED_CMS_ATTRIBUTES" ->
-            p_not_implemented CKA_REQUIRED_CMS_ATTRIBUTES
-        | "CKA_DEFAULT_CMS_ATTRIBUTES" ->
-            p_not_implemented CKA_DEFAULT_CMS_ATTRIBUTES
-        | "CKA_SUPPORTED_CMS_ATTRIBUTES" ->
-            p_not_implemented CKA_SUPPORTED_CMS_ATTRIBUTES
         | "CKA_ALLOWED_MECHANISMS" ->
             p_not_implemented CKA_ALLOWED_MECHANISMS
-        | "CKA_VENDOR_DEFINED" ->
-            p_not_implemented CKA_VENDOR_DEFINED
         | _ as ul ->
             try
               p_not_implemented
@@ -2321,68 +2069,17 @@ struct
       | CKA_COEFFICIENT      -> rsa_private
       | CKA_PRIME            -> []
       | CKA_SUBPRIME         -> []
-      (* | CKA_ECDSA_PARAMS     -> [ [ EC; Public; Private ] ] *)
       | CKA_EC_PARAMS        -> [ [ EC; Public; Private ] ]
       | CKA_EC_POINT         -> [ [ EC; Public ] ]
       | CKA_SUBJECT          -> [ [ Public; Private ] ]
-      | CKA_APPLICATION -> assert false
-      | CKA_OBJECT_ID -> assert false
-      | CKA_CERTIFICATE_TYPE -> assert false
-      | CKA_ISSUER -> assert false
-      | CKA_SERIAL_NUMBER -> assert false
-      | CKA_AC_ISSUER -> assert false
-      | CKA_OWNER -> assert false
-      | CKA_ATTR_TYPES -> assert false
-      | CKA_CERTIFICATE_CATEGORY -> assert false
-      | CKA_JAVA_MIDP_SECURITY_DOMAIN -> assert false
-      | CKA_URL -> assert false
-      | CKA_HASH_OF_SUBJECT_PUBLIC_KEY -> assert false
-      | CKA_HASH_OF_ISSUER_PUBLIC_KEY -> assert false
       | CKA_CHECK_VALUE -> assert false
       | CKA_START_DATE -> assert false
       | CKA_END_DATE -> assert false
-      | CKA_BASE -> assert false
       | CKA_PRIME_BITS -> assert false
       | CKA_SUBPRIME_BITS -> assert false
-      (* | CKA_SUB_PRIME_BITS -> assert false *)
-      | CKA_VALUE_BITS -> assert false
-      | CKA_SECONDARY_AUTH -> assert false
-      | CKA_AUTH_PIN_FLAGS -> assert false
       | CKA_WRAP_TEMPLATE -> assert false
       | CKA_UNWRAP_TEMPLATE -> assert false
-      | CKA_OTP_FORMAT -> assert false
-      | CKA_OTP_LENGTH -> assert false
-      | CKA_OTP_TIME_INTERVAL -> assert false
-      | CKA_OTP_USER_FRIENDLY_MODE -> assert false
-      | CKA_OTP_CHALLENGE_REQUIREMENT -> assert false
-      | CKA_OTP_TIME_REQUIREMENT -> assert false
-      | CKA_OTP_COUNTER_REQUIREMENT -> assert false
-      | CKA_OTP_PIN_REQUIREMENT -> assert false
-      | CKA_OTP_COUNTER -> assert false
-      | CKA_OTP_TIME -> assert false
-      | CKA_OTP_USER_IDENTIFIER -> assert false
-      | CKA_OTP_SERVICE_IDENTIFIER -> assert false
-      | CKA_OTP_SERVICE_LOGO -> assert false
-      | CKA_OTP_SERVICE_LOGO_TYPE -> assert false
-      | CKA_HW_FEATURE_TYPE -> assert false
-      | CKA_RESET_ON_INIT -> assert false
-      | CKA_HAS_RESET -> assert false
-      | CKA_PIXEL_X -> assert false
-      | CKA_PIXEL_Y -> assert false
-      | CKA_RESOLUTION -> assert false
-      | CKA_CHAR_ROWS -> assert false
-      | CKA_CHAR_COLUMNS -> assert false
-      | CKA_COLOR -> assert false
-      | CKA_BITS_PER_PIXEL -> assert false
-      | CKA_CHAR_SETS -> assert false
-      | CKA_ENCODING_METHODS -> assert false
-      | CKA_MIME_TYPES -> assert false
-      | CKA_MECHANISM_TYPE -> assert false
-      | CKA_REQUIRED_CMS_ATTRIBUTES -> assert false
-      | CKA_DEFAULT_CMS_ATTRIBUTES -> assert false
-      | CKA_SUPPORTED_CMS_ATTRIBUTES -> assert false
       | CKA_ALLOWED_MECHANISMS -> assert false
-      | CKA_VENDOR_DEFINED -> assert false
       | CKA_CS_UNKNOWN _ -> []
 
   (* Return whether [a] has all kinds [k]. *)

--- a/src/p11.mli
+++ b/src/p11.mli
@@ -874,21 +874,8 @@ sig
     | CKA_TOKEN : bool t
     | CKA_PRIVATE : bool t
     | CKA_LABEL : string t
-    | CKA_APPLICATION : not_implemented t
     | CKA_VALUE : string t
-    | CKA_OBJECT_ID : not_implemented t
-    | CKA_CERTIFICATE_TYPE : not_implemented t
-    | CKA_ISSUER : not_implemented t
-    | CKA_SERIAL_NUMBER : not_implemented t
-    | CKA_AC_ISSUER : not_implemented t
-    | CKA_OWNER : not_implemented t
-    | CKA_ATTR_TYPES : not_implemented t
     | CKA_TRUSTED : bool t
-    | CKA_CERTIFICATE_CATEGORY : not_implemented t
-    | CKA_JAVA_MIDP_SECURITY_DOMAIN : not_implemented t
-    | CKA_URL : not_implemented t
-    | CKA_HASH_OF_SUBJECT_PUBLIC_KEY : not_implemented t
-    | CKA_HASH_OF_ISSUER_PUBLIC_KEY : not_implemented t
     | CKA_CHECK_VALUE : not_implemented t
     | CKA_KEY_TYPE : Pkcs11.CK_KEY_TYPE.u t
     | CKA_SUBJECT : string t
@@ -916,11 +903,8 @@ sig
     | CKA_COEFFICIENT : Pkcs11.CK_BIGINT.t t
     | CKA_PRIME : Pkcs11.CK_BIGINT.t t
     | CKA_SUBPRIME : Pkcs11.CK_BIGINT.t t
-    | CKA_BASE : not_implemented t
     | CKA_PRIME_BITS : Pkcs11.CK_ULONG.t t
     | CKA_SUBPRIME_BITS : Pkcs11.CK_ULONG.t t
-    (* | CKA_SUB_PRIME_BITS : not_implemented t *)
-    | CKA_VALUE_BITS : not_implemented t
     | CKA_VALUE_LEN : Pkcs11.CK_ULONG.t t
     | CKA_EXTRACTABLE : bool t
     | CKA_LOCAL : bool t
@@ -931,45 +915,11 @@ sig
     (* | CKA_ECDSA_PARAMS : string t *)
     | CKA_EC_PARAMS : Key_parsers.Asn1.EC.Params.t t
     | CKA_EC_POINT : Key_parsers.Asn1.EC.point t
-    | CKA_SECONDARY_AUTH : not_implemented t
-    | CKA_AUTH_PIN_FLAGS : not_implemented t
     | CKA_ALWAYS_AUTHENTICATE : bool t
     | CKA_WRAP_WITH_TRUSTED : bool t
     | CKA_WRAP_TEMPLATE : not_implemented t
     | CKA_UNWRAP_TEMPLATE : not_implemented t
-    | CKA_OTP_FORMAT : not_implemented t
-    | CKA_OTP_LENGTH : not_implemented t
-    | CKA_OTP_TIME_INTERVAL : not_implemented t
-    | CKA_OTP_USER_FRIENDLY_MODE : not_implemented t
-    | CKA_OTP_CHALLENGE_REQUIREMENT : not_implemented t
-    | CKA_OTP_TIME_REQUIREMENT : not_implemented t
-    | CKA_OTP_COUNTER_REQUIREMENT : not_implemented t
-    | CKA_OTP_PIN_REQUIREMENT : not_implemented t
-    | CKA_OTP_COUNTER : not_implemented t
-    | CKA_OTP_TIME : not_implemented t
-    | CKA_OTP_USER_IDENTIFIER : not_implemented t
-    | CKA_OTP_SERVICE_IDENTIFIER : not_implemented t
-    | CKA_OTP_SERVICE_LOGO : not_implemented t
-    | CKA_OTP_SERVICE_LOGO_TYPE : not_implemented t
-    | CKA_HW_FEATURE_TYPE : not_implemented t
-    | CKA_RESET_ON_INIT : not_implemented t
-    | CKA_HAS_RESET : not_implemented t
-    | CKA_PIXEL_X : not_implemented t
-    | CKA_PIXEL_Y : not_implemented t
-    | CKA_RESOLUTION : not_implemented t
-    | CKA_CHAR_ROWS : not_implemented t
-    | CKA_CHAR_COLUMNS : not_implemented t
-    | CKA_COLOR : not_implemented t
-    | CKA_BITS_PER_PIXEL : not_implemented t
-    | CKA_CHAR_SETS : not_implemented t
-    | CKA_ENCODING_METHODS : not_implemented t
-    | CKA_MIME_TYPES : not_implemented t
-    | CKA_MECHANISM_TYPE : not_implemented t
-    | CKA_REQUIRED_CMS_ATTRIBUTES : not_implemented t
-    | CKA_DEFAULT_CMS_ATTRIBUTES : not_implemented t
-    | CKA_SUPPORTED_CMS_ATTRIBUTES : not_implemented t
     | CKA_ALLOWED_MECHANISMS : not_implemented t
-    | CKA_VENDOR_DEFINED : not_implemented t
     | CKA_CS_UNKNOWN: Unsigned.ULong.t -> not_implemented t
 
   type pack = Pkcs11.CK_ATTRIBUTE_TYPE.pack = Pack : 'a t -> pack

--- a/src/pkcs11_CK_ATTRIBUTE.ml
+++ b/src/pkcs11_CK_ATTRIBUTE.ml
@@ -190,22 +190,8 @@ let view (t : t) : pack =
   else if ul ==  _CKA_TOKEN                         then Pack (CKA_TOKEN, (unsafe_get_bool t))
   else if ul ==  _CKA_PRIVATE                       then Pack (CKA_PRIVATE, (unsafe_get_bool t))
   else if ul ==  _CKA_LABEL                         then Pack (CKA_LABEL, (unsafe_get_string t))
-  else if ul ==  _CKA_APPLICATION                   then Pack (CKA_APPLICATION, NOT_IMPLEMENTED (unsafe_get_string t))
   else if ul ==  _CKA_VALUE                         then Pack (CKA_VALUE, (unsafe_get_string t))
-  else if ul ==  _CKA_OBJECT_ID                     then Pack (CKA_OBJECT_ID, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_CERTIFICATE_TYPE              then Pack (CKA_CERTIFICATE_TYPE, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_ISSUER                        then Pack (CKA_ISSUER, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_SERIAL_NUMBER                 then Pack (CKA_SERIAL_NUMBER, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_AC_ISSUER                     then Pack (CKA_AC_ISSUER, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OWNER                         then Pack (CKA_OWNER, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_ATTR_TYPES                    then Pack (CKA_ATTR_TYPES, NOT_IMPLEMENTED (unsafe_get_string t))
   else if ul ==  _CKA_TRUSTED                       then Pack (CKA_TRUSTED, (unsafe_get_bool t))
-  else if ul ==  _CKA_CERTIFICATE_CATEGORY          then Pack (CKA_CERTIFICATE_CATEGORY, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_JAVA_MIDP_SECURITY_DOMAIN     then Pack (CKA_JAVA_MIDP_SECURITY_DOMAIN, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_URL                           then Pack (CKA_URL, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_HASH_OF_SUBJECT_PUBLIC_KEY    then Pack (CKA_HASH_OF_SUBJECT_PUBLIC_KEY, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_HASH_OF_ISSUER_PUBLIC_KEY     then Pack (CKA_HASH_OF_ISSUER_PUBLIC_KEY, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_CHECK_VALUE                   then Pack (CKA_CHECK_VALUE, NOT_IMPLEMENTED (unsafe_get_string t))
   else if ul ==  _CKA_KEY_TYPE                      then Pack (CKA_KEY_TYPE, (unsafe_get_key_type t |> Pkcs11_CK_KEY_TYPE.view))
   else if ul ==  _CKA_SUBJECT                       then Pack (CKA_SUBJECT,  (unsafe_get_string t))
   else if ul ==  _CKA_ID                            then Pack (CKA_ID,       (unsafe_get_string t))
@@ -219,8 +205,6 @@ let view (t : t) : pack =
   else if ul ==  _CKA_VERIFY                        then Pack (CKA_VERIFY, (unsafe_get_bool t))
   else if ul ==  _CKA_VERIFY_RECOVER                then Pack (CKA_VERIFY_RECOVER, (unsafe_get_bool t))
   else if ul ==  _CKA_DERIVE                        then Pack (CKA_DERIVE, (unsafe_get_bool t))
-  else if ul ==  _CKA_START_DATE                    then Pack (CKA_START_DATE, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_END_DATE                      then Pack (CKA_END_DATE, NOT_IMPLEMENTED (unsafe_get_string t))
   else if ul ==  _CKA_MODULUS                       then Pack (CKA_MODULUS, (unsafe_get_bigint t))
   else if ul ==  _CKA_MODULUS_BITS                  then Pack (CKA_MODULUS_BITS, (unsafe_get_ulong t))
   else if ul ==  _CKA_PUBLIC_EXPONENT               then Pack (CKA_PUBLIC_EXPONENT, (unsafe_get_bigint t))
@@ -232,11 +216,8 @@ let view (t : t) : pack =
   else if ul ==  _CKA_COEFFICIENT                   then Pack (CKA_COEFFICIENT, (unsafe_get_bigint t))
   else if ul ==  _CKA_PRIME                         then Pack (CKA_PRIME, (unsafe_get_bigint t))
   else if ul ==  _CKA_SUBPRIME                      then Pack (CKA_SUBPRIME, (unsafe_get_bigint t))
-  else if ul ==  _CKA_BASE                          then Pack (CKA_BASE, NOT_IMPLEMENTED (unsafe_get_string t))
   else if ul ==  _CKA_PRIME_BITS                    then Pack (CKA_PRIME_BITS, unsafe_get_ulong t)
   else if ul ==  _CKA_SUBPRIME_BITS                 then Pack (CKA_SUBPRIME_BITS, unsafe_get_ulong t)
-  (* else if ul ==  _CKA_SUB_PRIME_BITS                then Pack (CKA_SUB_PRIME_BITS, NOT_IMPLEMENTED (unsafe_get_string t)) *)
-  else if ul ==  _CKA_VALUE_BITS                    then Pack (CKA_VALUE_BITS, NOT_IMPLEMENTED (unsafe_get_string t))
   else if ul ==  _CKA_VALUE_LEN                     then Pack (CKA_VALUE_LEN, (unsafe_get_ulong t))
   else if ul ==  _CKA_EXTRACTABLE                   then Pack (CKA_EXTRACTABLE, (unsafe_get_bool t))
   else if ul ==  _CKA_LOCAL                         then Pack (CKA_LOCAL, (unsafe_get_bool t))
@@ -247,45 +228,8 @@ let view (t : t) : pack =
   (* else if ul ==  _CKA_ECDSA_PARAMS                  then Pack (CKA_ECDSA_PARAMS, (unsafe_get_string t)) *)
   else if ul ==  _CKA_EC_PARAMS                     then decode_cka_ec_params (unsafe_get_string t)
   else if ul ==  _CKA_EC_POINT                      then decode_cka_ec_point (unsafe_get_string t)
-  else if ul ==  _CKA_SECONDARY_AUTH                then Pack (CKA_SECONDARY_AUTH, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_AUTH_PIN_FLAGS                then Pack (CKA_AUTH_PIN_FLAGS, NOT_IMPLEMENTED (unsafe_get_string t))
   else if ul ==  _CKA_ALWAYS_AUTHENTICATE           then Pack (CKA_ALWAYS_AUTHENTICATE, (unsafe_get_bool t))
   else if ul ==  _CKA_WRAP_WITH_TRUSTED             then Pack (CKA_WRAP_WITH_TRUSTED,   (unsafe_get_bool t))
-  else if ul ==  _CKA_WRAP_TEMPLATE                 then Pack (CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_UNWRAP_TEMPLATE               then Pack (CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_FORMAT                    then Pack (CKA_OTP_FORMAT, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_LENGTH                    then Pack (CKA_OTP_LENGTH, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_TIME_INTERVAL             then Pack (CKA_OTP_TIME_INTERVAL, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_USER_FRIENDLY_MODE        then Pack (CKA_OTP_USER_FRIENDLY_MODE, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_CHALLENGE_REQUIREMENT     then Pack (CKA_OTP_CHALLENGE_REQUIREMENT, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_TIME_REQUIREMENT          then Pack (CKA_OTP_TIME_REQUIREMENT, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_COUNTER_REQUIREMENT       then Pack (CKA_OTP_COUNTER_REQUIREMENT, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_PIN_REQUIREMENT           then Pack (CKA_OTP_PIN_REQUIREMENT, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_COUNTER                   then Pack (CKA_OTP_COUNTER, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_TIME                      then Pack (CKA_OTP_TIME, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_USER_IDENTIFIER           then Pack (CKA_OTP_USER_IDENTIFIER, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_SERVICE_IDENTIFIER        then Pack (CKA_OTP_SERVICE_IDENTIFIER, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_SERVICE_LOGO              then Pack (CKA_OTP_SERVICE_LOGO, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_OTP_SERVICE_LOGO_TYPE         then Pack (CKA_OTP_SERVICE_LOGO_TYPE, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_HW_FEATURE_TYPE               then Pack (CKA_HW_FEATURE_TYPE, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_RESET_ON_INIT                 then Pack (CKA_RESET_ON_INIT, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_HAS_RESET                     then Pack (CKA_HAS_RESET, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_PIXEL_X                       then Pack (CKA_PIXEL_X, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_PIXEL_Y                       then Pack (CKA_PIXEL_Y, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_RESOLUTION                    then Pack (CKA_RESOLUTION, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_CHAR_ROWS                     then Pack (CKA_CHAR_ROWS, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_CHAR_COLUMNS                  then Pack (CKA_CHAR_COLUMNS, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_COLOR                         then Pack (CKA_COLOR, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_BITS_PER_PIXEL                then Pack (CKA_BITS_PER_PIXEL, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_CHAR_SETS                     then Pack (CKA_CHAR_SETS, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_ENCODING_METHODS              then Pack (CKA_ENCODING_METHODS, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_MIME_TYPES                    then Pack (CKA_MIME_TYPES, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_MECHANISM_TYPE                then Pack (CKA_MECHANISM_TYPE, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_REQUIRED_CMS_ATTRIBUTES       then Pack (CKA_REQUIRED_CMS_ATTRIBUTES, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_DEFAULT_CMS_ATTRIBUTES        then Pack (CKA_DEFAULT_CMS_ATTRIBUTES, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_SUPPORTED_CMS_ATTRIBUTES      then Pack (CKA_SUPPORTED_CMS_ATTRIBUTES, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_ALLOWED_MECHANISMS            then Pack (CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED (unsafe_get_string t))
-  else if ul ==  _CKA_VENDOR_DEFINED                then Pack (CKA_VENDOR_DEFINED, NOT_IMPLEMENTED (unsafe_get_string t))
   else
     begin
       Pkcs11_log.log @@ Printf.sprintf "Unknown CKA code: 0x%Lx" @@ Int64.of_string @@ Unsigned.ULong.to_string ul;
@@ -301,22 +245,8 @@ let make : type s . s u -> t = fun x ->
   | CKA_TOKEN, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_TOKEN b
   | CKA_PRIVATE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIVATE b
   | CKA_LABEL, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_LABEL s
-  | CKA_APPLICATION, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_APPLICATION s
   | CKA_VALUE, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VALUE s
-  | CKA_OBJECT_ID, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OBJECT_ID s
-  | CKA_CERTIFICATE_TYPE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CERTIFICATE_TYPE s
-  | CKA_ISSUER, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ISSUER s
-  | CKA_SERIAL_NUMBER, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SERIAL_NUMBER s
-  | CKA_AC_ISSUER, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_AC_ISSUER s
-  | CKA_OWNER, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OWNER s
-  | CKA_ATTR_TYPES, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ATTR_TYPES s
   | CKA_TRUSTED, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_TRUSTED b
-  | CKA_CERTIFICATE_CATEGORY, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CERTIFICATE_CATEGORY s
-  | CKA_JAVA_MIDP_SECURITY_DOMAIN, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_JAVA_MIDP_SECURITY_DOMAIN s
-  | CKA_URL, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_URL s
-  | CKA_HASH_OF_SUBJECT_PUBLIC_KEY, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_HASH_OF_SUBJECT_PUBLIC_KEY s
-  | CKA_HASH_OF_ISSUER_PUBLIC_KEY, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_HASH_OF_ISSUER_PUBLIC_KEY s
-  | CKA_CHECK_VALUE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CHECK_VALUE s
   | CKA_KEY_TYPE, ckk -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_TYPE (Pkcs11_CK_KEY_TYPE.make ckk)
   | CKA_SUBJECT, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SUBJECT s
   | CKA_ID, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ID s
@@ -330,8 +260,6 @@ let make : type s . s u -> t = fun x ->
   | CKA_VERIFY, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VERIFY b
   | CKA_VERIFY_RECOVER, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VERIFY_RECOVER b
   | CKA_DERIVE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_DERIVE b
-  | CKA_START_DATE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_START_DATE s
-  | CKA_END_DATE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_END_DATE s
   | CKA_MODULUS, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS n
   | CKA_MODULUS_BITS,     ul -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS_BITS     ul
   | CKA_PUBLIC_EXPONENT, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PUBLIC_EXPONENT n
@@ -343,11 +271,8 @@ let make : type s . s u -> t = fun x ->
   | CKA_COEFFICIENT, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_COEFFICIENT n
   | CKA_PRIME, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIME n
   | CKA_SUBPRIME, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SUBPRIME n
-  | CKA_BASE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_BASE s
   | CKA_PRIME_BITS, ul -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIME_BITS ul
   | CKA_SUBPRIME_BITS, ul -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SUBPRIME_BITS ul
-  (* | CKA_SUB_PRIME_BITS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SUB_PRIME_BITS s *)
-  | CKA_VALUE_BITS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VALUE_BITS s
   | CKA_VALUE_LEN, ul -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VALUE_LEN ul
   | CKA_EXTRACTABLE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_EXTRACTABLE b
   | CKA_LOCAL,  b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_LOCAL  b
@@ -361,45 +286,8 @@ let make : type s . s u -> t = fun x ->
   | CKA_EC_PARAMS, p ->
       encode_ec_params p |> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_EC_PARAMS
   | CKA_EC_POINT, p -> encode_ec_point p |> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_EC_POINT
-  | CKA_SECONDARY_AUTH, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SECONDARY_AUTH s
-  | CKA_AUTH_PIN_FLAGS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_AUTH_PIN_FLAGS s
   | CKA_ALWAYS_AUTHENTICATE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ALWAYS_AUTHENTICATE b
   | CKA_WRAP_WITH_TRUSTED,   b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_WRAP_WITH_TRUSTED   b
-  | CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_WRAP_TEMPLATE s
-  | CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_UNWRAP_TEMPLATE s
-  | CKA_OTP_FORMAT, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_FORMAT s
-  | CKA_OTP_LENGTH, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_LENGTH s
-  | CKA_OTP_TIME_INTERVAL, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_TIME_INTERVAL s
-  | CKA_OTP_USER_FRIENDLY_MODE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_USER_FRIENDLY_MODE s
-  | CKA_OTP_CHALLENGE_REQUIREMENT, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_CHALLENGE_REQUIREMENT s
-  | CKA_OTP_TIME_REQUIREMENT, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_TIME_REQUIREMENT s
-  | CKA_OTP_COUNTER_REQUIREMENT, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_COUNTER_REQUIREMENT s
-  | CKA_OTP_PIN_REQUIREMENT, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_PIN_REQUIREMENT s
-  | CKA_OTP_COUNTER, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_COUNTER s
-  | CKA_OTP_TIME, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_TIME s
-  | CKA_OTP_USER_IDENTIFIER, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_USER_IDENTIFIER s
-  | CKA_OTP_SERVICE_IDENTIFIER, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_SERVICE_IDENTIFIER s
-  | CKA_OTP_SERVICE_LOGO, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_SERVICE_LOGO s
-  | CKA_OTP_SERVICE_LOGO_TYPE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_OTP_SERVICE_LOGO_TYPE s
-  | CKA_HW_FEATURE_TYPE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_HW_FEATURE_TYPE s
-  | CKA_RESET_ON_INIT, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_RESET_ON_INIT s
-  | CKA_HAS_RESET, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_HAS_RESET s
-  | CKA_PIXEL_X, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PIXEL_X s
-  | CKA_PIXEL_Y, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PIXEL_Y s
-  | CKA_RESOLUTION, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_RESOLUTION s
-  | CKA_CHAR_ROWS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CHAR_ROWS s
-  | CKA_CHAR_COLUMNS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CHAR_COLUMNS s
-  | CKA_COLOR, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_COLOR s
-  | CKA_BITS_PER_PIXEL, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_BITS_PER_PIXEL s
-  | CKA_CHAR_SETS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CHAR_SETS s
-  | CKA_ENCODING_METHODS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ENCODING_METHODS s
-  | CKA_MIME_TYPES, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MIME_TYPES s
-  | CKA_MECHANISM_TYPE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MECHANISM_TYPE s
-  | CKA_REQUIRED_CMS_ATTRIBUTES, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_REQUIRED_CMS_ATTRIBUTES s
-  | CKA_DEFAULT_CMS_ATTRIBUTES, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_DEFAULT_CMS_ATTRIBUTES s
-  | CKA_SUPPORTED_CMS_ATTRIBUTES, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SUPPORTED_CMS_ATTRIBUTES s
-  | CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ALLOWED_MECHANISMS s
-  | CKA_VENDOR_DEFINED, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VENDOR_DEFINED s
   | CKA_CS_UNKNOWN ul, NOT_IMPLEMENTED s ->
       string ul s
 
@@ -422,22 +310,8 @@ let to_string_pair =
       | CKA_TOKEN, x               -> bool "CKA_TOKEN" x
       | CKA_PRIVATE, x             -> bool "CKA_PRIVATE" x
       | CKA_LABEL, x               -> string "CKA_LABEL" x
-      | CKA_APPLICATION, NOT_IMPLEMENTED x -> string "CKA_APPLICATION" x
       | CKA_VALUE, x               -> string "CKA_VALUE" x
-      | CKA_OBJECT_ID, NOT_IMPLEMENTED x -> string "CKA_OBJECT_ID" x
-      | CKA_CERTIFICATE_TYPE, NOT_IMPLEMENTED x -> string "CKA_CERTIFICATE_TYPE" x
-      | CKA_ISSUER, NOT_IMPLEMENTED x -> string "CKA_ISSUER" x
-      | CKA_SERIAL_NUMBER, NOT_IMPLEMENTED x -> string "CKA_SERIAL_NUMBER" x
-      | CKA_AC_ISSUER, NOT_IMPLEMENTED x -> string "CKA_AC_ISSUER" x
-      | CKA_OWNER, NOT_IMPLEMENTED x -> string "CKA_OWNER" x
-      | CKA_ATTR_TYPES, NOT_IMPLEMENTED x -> string "CKA_ATTR_TYPES" x
       | CKA_TRUSTED, x             -> bool "CKA_TRUSTED" x
-      | CKA_CERTIFICATE_CATEGORY, NOT_IMPLEMENTED x -> string "CKA_CERTIFICATE_CATEGORY" x
-      | CKA_JAVA_MIDP_SECURITY_DOMAIN, NOT_IMPLEMENTED x -> string "CKA_JAVA_MIDP_SECURITY_DOMAIN" x
-      | CKA_URL, NOT_IMPLEMENTED x -> string "CKA_URL" x
-      | CKA_HASH_OF_SUBJECT_PUBLIC_KEY, NOT_IMPLEMENTED x -> string "CKA_HASH_OF_SUBJECT_PUBLIC_KEY" x
-      | CKA_HASH_OF_ISSUER_PUBLIC_KEY, NOT_IMPLEMENTED x -> string "CKA_HASH_OF_ISSUER_PUBLIC_KEY" x
-      | CKA_CHECK_VALUE, NOT_IMPLEMENTED x -> string "CKA_CHECK_VALUE" x
       | CKA_KEY_TYPE, x            -> key_type "CKA_KEY_TYPE" x
       | CKA_SUBJECT, x             -> string "CKA_SUBJECT" x
       | CKA_ID, x                  -> string "CKA_ID" x
@@ -451,8 +325,6 @@ let to_string_pair =
       | CKA_VERIFY, x              -> bool "CKA_VERIFY" x
       | CKA_VERIFY_RECOVER, x      -> bool "CKA_VERIFY_RECOVER" x
       | CKA_DERIVE, x              -> bool "CKA_DERIVE" x
-      | CKA_START_DATE, NOT_IMPLEMENTED x -> string "CKA_START_DATE" x
-      | CKA_END_DATE, NOT_IMPLEMENTED x -> string "CKA_END_DATE" x
       | CKA_MODULUS,  x            -> bigint "CKA_MODULUS" x
       | CKA_MODULUS_BITS,     x    -> ulong "CKA_MODULUS_BITS" x
       | CKA_PUBLIC_EXPONENT,  x    -> bigint "CKA_PUBLIC_EXPONENT" x
@@ -464,11 +336,8 @@ let to_string_pair =
       | CKA_COEFFICIENT,      x    -> bigint "CKA_COEFFICIENT" x
       | CKA_PRIME,            x    -> bigint "CKA_PRIME" x
       | CKA_SUBPRIME,         x    -> bigint "CKA_SUBPRIME" x
-      | CKA_BASE, NOT_IMPLEMENTED x -> string "CKA_BASE" x
       | CKA_PRIME_BITS,  x          -> ulong "CKA_PRIME_BITS" x
       | CKA_SUBPRIME_BITS, x        -> ulong "CKA_SUBPRIME_BITS" x
-      (* | CKA_SUB_PRIME_BITS, NOT_IMPLEMENTED x -> string "CKA_SUB_PRIME_BITS" x *)
-      | CKA_VALUE_BITS, NOT_IMPLEMENTED x -> string "CKA_VALUE_BITS" x
       | CKA_VALUE_LEN, x           -> ulong "CKA_VALUE_LEN" x
       | CKA_EXTRACTABLE, x         -> bool "CKA_EXTRACTABLE" x
       | CKA_LOCAL,  x              -> bool "CKA_LOCAL" x
@@ -479,45 +348,8 @@ let to_string_pair =
       (* | CKA_ECDSA_PARAMS, x        -> string "CKA_ECDSA_PARAMS" x *)
       | CKA_EC_PARAMS, x           -> ec_parameters "CKA_EC_PARAMS" x
       | CKA_EC_POINT, x            -> ec_point "CKA_EC_POINT" x
-      | CKA_SECONDARY_AUTH, NOT_IMPLEMENTED x -> string "CKA_SECONDARY_AUTH" x
-      | CKA_AUTH_PIN_FLAGS, NOT_IMPLEMENTED x -> string "CKA_AUTH_PIN_FLAGS" x
       | CKA_ALWAYS_AUTHENTICATE, x -> bool "CKA_ALWAYS_AUTHENTICATE" x
       | CKA_WRAP_WITH_TRUSTED,   x -> bool "CKA_WRAP_WITH_TRUSTED" x
-      | CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED x -> string "CKA_WRAP_TEMPLATE" x
-      | CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED x -> string "CKA_UNWRAP_TEMPLATE" x
-      | CKA_OTP_FORMAT, NOT_IMPLEMENTED x -> string "CKA_OTP_FORMAT" x
-      | CKA_OTP_LENGTH, NOT_IMPLEMENTED x -> string "CKA_OTP_LENGTH" x
-      | CKA_OTP_TIME_INTERVAL, NOT_IMPLEMENTED x -> string "CKA_OTP_TIME_INTERVAL" x
-      | CKA_OTP_USER_FRIENDLY_MODE, NOT_IMPLEMENTED x -> string "CKA_OTP_USER_FRIENDLY_MODE" x
-      | CKA_OTP_CHALLENGE_REQUIREMENT, NOT_IMPLEMENTED x -> string "CKA_OTP_CHALLENGE_REQUIREMENT" x
-      | CKA_OTP_TIME_REQUIREMENT, NOT_IMPLEMENTED x -> string "CKA_OTP_TIME_REQUIREMENT" x
-      | CKA_OTP_COUNTER_REQUIREMENT, NOT_IMPLEMENTED x -> string "CKA_OTP_COUNTER_REQUIREMENT" x
-      | CKA_OTP_PIN_REQUIREMENT, NOT_IMPLEMENTED x -> string "CKA_OTP_PIN_REQUIREMENT" x
-      | CKA_OTP_COUNTER, NOT_IMPLEMENTED x -> string "CKA_OTP_COUNTER" x
-      | CKA_OTP_TIME, NOT_IMPLEMENTED x -> string "CKA_OTP_TIME" x
-      | CKA_OTP_USER_IDENTIFIER, NOT_IMPLEMENTED x -> string "CKA_OTP_USER_IDENTIFIER" x
-      | CKA_OTP_SERVICE_IDENTIFIER, NOT_IMPLEMENTED x -> string "CKA_OTP_SERVICE_IDENTIFIER" x
-      | CKA_OTP_SERVICE_LOGO, NOT_IMPLEMENTED x -> string "CKA_OTP_SERVICE_LOGO" x
-      | CKA_OTP_SERVICE_LOGO_TYPE, NOT_IMPLEMENTED x -> string "CKA_OTP_SERVICE_LOGO_TYPE" x
-      | CKA_HW_FEATURE_TYPE, NOT_IMPLEMENTED x -> string "CKA_HW_FEATURE_TYPE" x
-      | CKA_RESET_ON_INIT, NOT_IMPLEMENTED x -> string "CKA_RESET_ON_INIT" x
-      | CKA_HAS_RESET, NOT_IMPLEMENTED x -> string "CKA_HAS_RESET" x
-      | CKA_PIXEL_X, NOT_IMPLEMENTED x -> string "CKA_PIXEL_X" x
-      | CKA_PIXEL_Y, NOT_IMPLEMENTED x -> string "CKA_PIXEL_Y" x
-      | CKA_RESOLUTION, NOT_IMPLEMENTED x -> string "CKA_RESOLUTION" x
-      | CKA_CHAR_ROWS, NOT_IMPLEMENTED x -> string "CKA_CHAR_ROWS" x
-      | CKA_CHAR_COLUMNS, NOT_IMPLEMENTED x -> string "CKA_CHAR_COLUMNS" x
-      | CKA_COLOR, NOT_IMPLEMENTED x -> string "CKA_COLOR" x
-      | CKA_BITS_PER_PIXEL, NOT_IMPLEMENTED x -> string "CKA_BITS_PER_PIXEL" x
-      | CKA_CHAR_SETS, NOT_IMPLEMENTED x -> string "CKA_CHAR_SETS" x
-      | CKA_ENCODING_METHODS, NOT_IMPLEMENTED x -> string "CKA_ENCODING_METHODS" x
-      | CKA_MIME_TYPES, NOT_IMPLEMENTED x -> string "CKA_MIME_TYPES" x
-      | CKA_MECHANISM_TYPE, NOT_IMPLEMENTED x -> string "CKA_MECHANISM_TYPE" x
-      | CKA_REQUIRED_CMS_ATTRIBUTES, NOT_IMPLEMENTED x -> string "CKA_REQUIRED_CMS_ATTRIBUTES" x
-      | CKA_DEFAULT_CMS_ATTRIBUTES, NOT_IMPLEMENTED x -> string "CKA_DEFAULT_CMS_ATTRIBUTES" x
-      | CKA_SUPPORTED_CMS_ATTRIBUTES, NOT_IMPLEMENTED x -> string "CKA_SUPPORTED_CMS_ATTRIBUTES" x
-      | CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED x -> string "CKA_ALLOWED_MECHANISMS" x
-      | CKA_VENDOR_DEFINED, NOT_IMPLEMENTED x -> string "CKA_VENDOR_DEFINED" x
       | CKA_CS_UNKNOWN ul, NOT_IMPLEMENTED x -> string (Unsigned.ULong.to_string ul) x
 
 let to_string x =
@@ -589,70 +421,12 @@ let compare : type a b. a u -> b u -> int = fun a b ->
       | (CKA_MODIFIABLE, a_param), (CKA_MODIFIABLE, b_param) -> compare_bool a_param b_param
       | (CKA_ALWAYS_AUTHENTICATE, a_param), (CKA_ALWAYS_AUTHENTICATE, b_param) -> compare_bool a_param b_param
       | (CKA_WRAP_WITH_TRUSTED, a_param), (CKA_WRAP_WITH_TRUSTED, b_param) -> compare_bool a_param b_param
-
       | (CKA_LABEL, a_param), (CKA_LABEL, b_param) -> compare_string a_param b_param
       | (CKA_VALUE, a_param), (CKA_VALUE, b_param) -> compare_string a_param b_param
       | (CKA_SUBJECT, a_param), (CKA_SUBJECT, b_param) -> compare_string a_param b_param
       | (CKA_ID, a_param), (CKA_ID, b_param) -> compare_string a_param b_param
-
-      | (CKA_APPLICATION, NOT_IMPLEMENTED a_param), (CKA_APPLICATION, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OBJECT_ID, NOT_IMPLEMENTED a_param), (CKA_OBJECT_ID, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_CERTIFICATE_TYPE, NOT_IMPLEMENTED a_param), (CKA_CERTIFICATE_TYPE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_ISSUER, NOT_IMPLEMENTED a_param), (CKA_ISSUER, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_SERIAL_NUMBER, NOT_IMPLEMENTED a_param), (CKA_SERIAL_NUMBER, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_AC_ISSUER, NOT_IMPLEMENTED a_param), (CKA_AC_ISSUER, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OWNER, NOT_IMPLEMENTED a_param), (CKA_OWNER, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_ATTR_TYPES, NOT_IMPLEMENTED a_param), (CKA_ATTR_TYPES, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_CERTIFICATE_CATEGORY, NOT_IMPLEMENTED a_param), (CKA_CERTIFICATE_CATEGORY, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_JAVA_MIDP_SECURITY_DOMAIN, NOT_IMPLEMENTED a_param), (CKA_JAVA_MIDP_SECURITY_DOMAIN, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_URL, NOT_IMPLEMENTED a_param), (CKA_URL, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_HASH_OF_SUBJECT_PUBLIC_KEY, NOT_IMPLEMENTED a_param), (CKA_HASH_OF_SUBJECT_PUBLIC_KEY, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_HASH_OF_ISSUER_PUBLIC_KEY, NOT_IMPLEMENTED a_param), (CKA_HASH_OF_ISSUER_PUBLIC_KEY, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_CHECK_VALUE, NOT_IMPLEMENTED a_param), (CKA_CHECK_VALUE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_START_DATE, NOT_IMPLEMENTED a_param), (CKA_START_DATE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_END_DATE, NOT_IMPLEMENTED a_param), (CKA_END_DATE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_BASE, NOT_IMPLEMENTED a_param), (CKA_BASE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
       | (CKA_PRIME_BITS, a_param), (CKA_PRIME_BITS,  b_param) -> compare_ulong a_param b_param
       | (CKA_SUBPRIME_BITS, a_param), (CKA_SUBPRIME_BITS, b_param) -> compare_ulong a_param b_param
-      (* | (CKA_SUB_PRIME_BITS, NOT_IMPLEMENTED a_param), (CKA_SUB_PRIME_BITS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param *)
-      | (CKA_VALUE_BITS, NOT_IMPLEMENTED a_param), (CKA_VALUE_BITS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_SECONDARY_AUTH, NOT_IMPLEMENTED a_param), (CKA_SECONDARY_AUTH, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_AUTH_PIN_FLAGS, NOT_IMPLEMENTED a_param), (CKA_AUTH_PIN_FLAGS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED a_param), (CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED a_param), (CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_FORMAT, NOT_IMPLEMENTED a_param), (CKA_OTP_FORMAT, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_LENGTH, NOT_IMPLEMENTED a_param), (CKA_OTP_LENGTH, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_TIME_INTERVAL, NOT_IMPLEMENTED a_param), (CKA_OTP_TIME_INTERVAL, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_USER_FRIENDLY_MODE, NOT_IMPLEMENTED a_param), (CKA_OTP_USER_FRIENDLY_MODE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_CHALLENGE_REQUIREMENT, NOT_IMPLEMENTED a_param), (CKA_OTP_CHALLENGE_REQUIREMENT, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_TIME_REQUIREMENT, NOT_IMPLEMENTED a_param), (CKA_OTP_TIME_REQUIREMENT, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_COUNTER_REQUIREMENT, NOT_IMPLEMENTED a_param), (CKA_OTP_COUNTER_REQUIREMENT, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_PIN_REQUIREMENT, NOT_IMPLEMENTED a_param), (CKA_OTP_PIN_REQUIREMENT, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_COUNTER, NOT_IMPLEMENTED a_param), (CKA_OTP_COUNTER, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_TIME, NOT_IMPLEMENTED a_param), (CKA_OTP_TIME, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_USER_IDENTIFIER, NOT_IMPLEMENTED a_param), (CKA_OTP_USER_IDENTIFIER, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_SERVICE_IDENTIFIER, NOT_IMPLEMENTED a_param), (CKA_OTP_SERVICE_IDENTIFIER, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_SERVICE_LOGO, NOT_IMPLEMENTED a_param), (CKA_OTP_SERVICE_LOGO, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_OTP_SERVICE_LOGO_TYPE, NOT_IMPLEMENTED a_param), (CKA_OTP_SERVICE_LOGO_TYPE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_HW_FEATURE_TYPE, NOT_IMPLEMENTED a_param), (CKA_HW_FEATURE_TYPE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_RESET_ON_INIT, NOT_IMPLEMENTED a_param), (CKA_RESET_ON_INIT, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_HAS_RESET, NOT_IMPLEMENTED a_param), (CKA_HAS_RESET, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_PIXEL_X, NOT_IMPLEMENTED a_param), (CKA_PIXEL_X, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_PIXEL_Y, NOT_IMPLEMENTED a_param), (CKA_PIXEL_Y, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_RESOLUTION, NOT_IMPLEMENTED a_param), (CKA_RESOLUTION, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_CHAR_ROWS, NOT_IMPLEMENTED a_param), (CKA_CHAR_ROWS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_CHAR_COLUMNS, NOT_IMPLEMENTED a_param), (CKA_CHAR_COLUMNS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_COLOR, NOT_IMPLEMENTED a_param), (CKA_COLOR, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_BITS_PER_PIXEL, NOT_IMPLEMENTED a_param), (CKA_BITS_PER_PIXEL, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_CHAR_SETS, NOT_IMPLEMENTED a_param), (CKA_CHAR_SETS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_ENCODING_METHODS, NOT_IMPLEMENTED a_param), (CKA_ENCODING_METHODS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_MIME_TYPES, NOT_IMPLEMENTED a_param), (CKA_MIME_TYPES, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_MECHANISM_TYPE, NOT_IMPLEMENTED a_param), (CKA_MECHANISM_TYPE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_REQUIRED_CMS_ATTRIBUTES, NOT_IMPLEMENTED a_param), (CKA_REQUIRED_CMS_ATTRIBUTES, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_DEFAULT_CMS_ATTRIBUTES, NOT_IMPLEMENTED a_param), (CKA_DEFAULT_CMS_ATTRIBUTES, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_SUPPORTED_CMS_ATTRIBUTES, NOT_IMPLEMENTED a_param), (CKA_SUPPORTED_CMS_ATTRIBUTES, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED a_param), (CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_VENDOR_DEFINED, NOT_IMPLEMENTED a_param), (CKA_VENDOR_DEFINED, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
       | (CKA_CS_UNKNOWN a_ul, NOT_IMPLEMENTED a_param),
         (CKA_CS_UNKNOWN b_ul, NOT_IMPLEMENTED b_param) ->
           let cmp = Unsigned.ULong.compare a_ul b_ul in
@@ -700,67 +474,10 @@ let compare : type a b. a u -> b u -> int = fun a b ->
       | (CKA_COEFFICIENT, _), _ -> assert false
       | (CKA_PRIME, _), _ -> assert false
       | (CKA_SUBPRIME, _), _ -> assert false
-      (* | (CKA_ECDSA_PARAMS, _), _ -> assert false *)
       | (CKA_EC_PARAMS, _), _ -> assert false
       | (CKA_EC_POINT, _), _ -> assert false
-      | (CKA_APPLICATION, _), _ -> assert false
-      | (CKA_OBJECT_ID, _), _ -> assert false
-      | (CKA_CERTIFICATE_TYPE, _), _ -> assert false
-      | (CKA_ISSUER, _), _ -> assert false
-      | (CKA_SERIAL_NUMBER, _), _ -> assert false
-      | (CKA_AC_ISSUER, _), _ -> assert false
-      | (CKA_OWNER, _), _ -> assert false
-      | (CKA_ATTR_TYPES, _), _ -> assert false
-      | (CKA_CERTIFICATE_CATEGORY, _), _ -> assert false
-      | (CKA_JAVA_MIDP_SECURITY_DOMAIN, _), _ -> assert false
-      | (CKA_URL, _), _ -> assert false
-      | (CKA_HASH_OF_SUBJECT_PUBLIC_KEY, _), _ -> assert false
-      | (CKA_HASH_OF_ISSUER_PUBLIC_KEY, _), _ -> assert false
-      | (CKA_CHECK_VALUE, _), _ -> assert false
-      | (CKA_START_DATE, _), _ -> assert false
-      | (CKA_END_DATE, _), _ -> assert false
-      | (CKA_BASE, _), _ -> assert false
       | (CKA_PRIME_BITS, _), _ -> assert false
       | (CKA_SUBPRIME_BITS, _), _ -> assert false
-      (* | (CKA_SUB_PRIME_BITS, _), _ -> assert false *)
-      | (CKA_VALUE_BITS, _), _ -> assert false
-      | (CKA_SECONDARY_AUTH, _), _ -> assert false
-      | (CKA_AUTH_PIN_FLAGS, _), _ -> assert false
-      | (CKA_WRAP_TEMPLATE, _), _ -> assert false
-      | (CKA_UNWRAP_TEMPLATE, _), _ -> assert false
-      | (CKA_OTP_FORMAT, _), _ -> assert false
-      | (CKA_OTP_LENGTH, _), _ -> assert false
-      | (CKA_OTP_TIME_INTERVAL, _), _ -> assert false
-      | (CKA_OTP_USER_FRIENDLY_MODE, _), _ -> assert false
-      | (CKA_OTP_CHALLENGE_REQUIREMENT, _), _ -> assert false
-      | (CKA_OTP_TIME_REQUIREMENT, _), _ -> assert false
-      | (CKA_OTP_COUNTER_REQUIREMENT, _), _ -> assert false
-      | (CKA_OTP_PIN_REQUIREMENT, _), _ -> assert false
-      | (CKA_OTP_COUNTER, _), _ -> assert false
-      | (CKA_OTP_TIME, _), _ -> assert false
-      | (CKA_OTP_USER_IDENTIFIER, _), _ -> assert false
-      | (CKA_OTP_SERVICE_IDENTIFIER, _), _ -> assert false
-      | (CKA_OTP_SERVICE_LOGO, _), _ -> assert false
-      | (CKA_OTP_SERVICE_LOGO_TYPE, _), _ -> assert false
-      | (CKA_HW_FEATURE_TYPE, _), _ -> assert false
-      | (CKA_RESET_ON_INIT, _), _ -> assert false
-      | (CKA_HAS_RESET, _), _ -> assert false
-      | (CKA_PIXEL_X, _), _ -> assert false
-      | (CKA_PIXEL_Y, _), _ -> assert false
-      | (CKA_RESOLUTION, _), _ -> assert false
-      | (CKA_CHAR_ROWS, _), _ -> assert false
-      | (CKA_CHAR_COLUMNS, _), _ -> assert false
-      | (CKA_COLOR, _), _ -> assert false
-      | (CKA_BITS_PER_PIXEL, _), _ -> assert false
-      | (CKA_CHAR_SETS, _), _ -> assert false
-      | (CKA_ENCODING_METHODS, _), _ -> assert false
-      | (CKA_MIME_TYPES, _), _ -> assert false
-      | (CKA_MECHANISM_TYPE, _), _ -> assert false
-      | (CKA_REQUIRED_CMS_ATTRIBUTES, _), _ -> assert false
-      | (CKA_DEFAULT_CMS_ATTRIBUTES, _), _ -> assert false
-      | (CKA_SUPPORTED_CMS_ATTRIBUTES, _), _ -> assert false
-      | (CKA_ALLOWED_MECHANISMS, _), _ -> assert false
-      | (CKA_VENDOR_DEFINED, _), _ -> assert false
       | (CKA_CS_UNKNOWN _, _), _ -> assert false
 
 let compare_pack (Pack a) (Pack b) = compare a b

--- a/src/pkcs11_CK_ATTRIBUTE_SET.ml
+++ b/src/pkcs11_CK_ATTRIBUTE_SET.ml
@@ -66,22 +66,8 @@ let update (Pack x) t =
     | CKA_TOKEN, b -> boolean t b
     | CKA_PRIVATE, b -> boolean t b
     | CKA_LABEL, s -> string t s
-    | CKA_APPLICATION, not_implemented -> assert false
     | CKA_VALUE, s -> string t s
-    | CKA_OBJECT_ID, not_implemented -> assert false
-    | CKA_CERTIFICATE_TYPE, not_implemented -> assert false
-    | CKA_ISSUER, not_implemented -> assert false
-    | CKA_SERIAL_NUMBER, not_implemented -> assert false
-    | CKA_AC_ISSUER, not_implemented -> assert false
-    | CKA_OWNER, not_implemented -> assert false
-    | CKA_ATTR_TYPES, not_implemented -> assert false
     | CKA_TRUSTED, b -> boolean t b
-    | CKA_CERTIFICATE_CATEGORY, not_implemented -> assert false
-    | CKA_JAVA_MIDP_SECURITY_DOMAIN, not_implemented -> assert false
-    | CKA_URL, not_implemented -> assert false
-    | CKA_HASH_OF_SUBJECT_PUBLIC_KEY, not_implemented -> assert false
-    | CKA_HASH_OF_ISSUER_PUBLIC_KEY, not_implemented -> assert false
-    | CKA_CHECK_VALUE, not_implemented -> assert false
     | CKA_KEY_TYPE, ckk -> ulong t (Pkcs11_CK_KEY_TYPE.make ckk)
     | CKA_SUBJECT, s -> string t s
     | CKA_ID, s -> string t s
@@ -95,8 +81,6 @@ let update (Pack x) t =
     | CKA_VERIFY, b -> boolean t b
     | CKA_VERIFY_RECOVER, b -> boolean t b
     | CKA_DERIVE, b -> boolean t b
-    | CKA_START_DATE, not_implemented -> assert false
-    | CKA_END_DATE, not_implemented -> assert false
     | CKA_MODULUS, n -> bigint t n
     | CKA_MODULUS_BITS,     ul -> ulong t ul
     | CKA_PUBLIC_EXPONENT, n -> bigint t n
@@ -108,10 +92,8 @@ let update (Pack x) t =
     | CKA_COEFFICIENT, n -> bigint t n
     | CKA_PRIME, n -> bigint t n
     | CKA_SUBPRIME, n -> bigint t n
-    | CKA_BASE, not_implemented -> assert false
-    | CKA_PRIME_BITS, not_implemented -> assert false
+    | CKA_PRIME_BITS, _ -> assert false
     | CKA_SUBPRIME_BITS, not_implemented -> assert false
-    | CKA_VALUE_BITS, not_implemented -> assert false
     | CKA_VALUE_LEN, ul -> ulong t ul
     | CKA_EXTRACTABLE, b -> boolean t b
     | CKA_LOCAL,  b -> boolean t b
@@ -121,43 +103,6 @@ let update (Pack x) t =
     | CKA_MODIFIABLE, b -> boolean t b
     | CKA_EC_PARAMS, s -> assert false
     | CKA_EC_POINT, s -> assert false
-    | CKA_SECONDARY_AUTH, not_implemented -> assert false
-    | CKA_AUTH_PIN_FLAGS, not_implemented -> assert false
     | CKA_ALWAYS_AUTHENTICATE, b -> boolean t b
     | CKA_WRAP_WITH_TRUSTED,   b -> boolean t b
-    | CKA_WRAP_TEMPLATE, not_implemented -> assert false
-    | CKA_UNWRAP_TEMPLATE, not_implemented -> assert false
-    | CKA_OTP_FORMAT, not_implemented -> assert false
-    | CKA_OTP_LENGTH, not_implemented -> assert false
-    | CKA_OTP_TIME_INTERVAL, not_implemented -> assert false
-    | CKA_OTP_USER_FRIENDLY_MODE, not_implemented -> assert false
-    | CKA_OTP_CHALLENGE_REQUIREMENT, not_implemented -> assert false
-    | CKA_OTP_TIME_REQUIREMENT, not_implemented -> assert false
-    | CKA_OTP_COUNTER_REQUIREMENT, not_implemented -> assert false
-    | CKA_OTP_PIN_REQUIREMENT, not_implemented -> assert false
-    | CKA_OTP_COUNTER, not_implemented -> assert false
-    | CKA_OTP_TIME, not_implemented -> assert false
-    | CKA_OTP_USER_IDENTIFIER, not_implemented -> assert false
-    | CKA_OTP_SERVICE_IDENTIFIER, not_implemented -> assert false
-    | CKA_OTP_SERVICE_LOGO, not_implemented -> assert false
-    | CKA_OTP_SERVICE_LOGO_TYPE, not_implemented -> assert false
-    | CKA_HW_FEATURE_TYPE, not_implemented -> assert false
-    | CKA_RESET_ON_INIT, not_implemented -> assert false
-    | CKA_HAS_RESET, not_implemented -> assert false
-    | CKA_PIXEL_X, not_implemented -> assert false
-    | CKA_PIXEL_Y, not_implemented -> assert false
-    | CKA_RESOLUTION, not_implemented -> assert false
-    | CKA_CHAR_ROWS, not_implemented -> assert false
-    | CKA_CHAR_COLUMNS, not_implemented -> assert false
-    | CKA_COLOR, not_implemented -> assert false
-    | CKA_BITS_PER_PIXEL, not_implemented -> assert false
-    | CKA_CHAR_SETS, not_implemented -> assert false
-    | CKA_ENCODING_METHODS, not_implemented -> assert false
-    | CKA_MIME_TYPES, not_implemented -> assert false
-    | CKA_MECHANISM_TYPE, not_implemented -> assert false
-    | CKA_REQUIRED_CMS_ATTRIBUTES, not_implemented -> assert false
-    | CKA_DEFAULT_CMS_ATTRIBUTES, not_implemented -> assert false
-    | CKA_SUPPORTED_CMS_ATTRIBUTES, not_implemented -> assert false
-    | CKA_ALLOWED_MECHANISMS, not_implemented -> assert false
-    | CKA_VENDOR_DEFINED, not_implemented -> assert false
     | CKA_CS_UNKNOWN _, _ -> assert false

--- a/src/pkcs11_CK_ATTRIBUTE_TYPE.ml
+++ b/src/pkcs11_CK_ATTRIBUTE_TYPE.ml
@@ -9,21 +9,8 @@ type _ u =
   | CKA_TOKEN : bool u
   | CKA_PRIVATE : bool u
   | CKA_LABEL : string u
-  | CKA_APPLICATION : not_implemented u
   | CKA_VALUE : string u
-  | CKA_OBJECT_ID : not_implemented u
-  | CKA_CERTIFICATE_TYPE : not_implemented u
-  | CKA_ISSUER : not_implemented u
-  | CKA_SERIAL_NUMBER : not_implemented u
-  | CKA_AC_ISSUER : not_implemented u
-  | CKA_OWNER : not_implemented u
-  | CKA_ATTR_TYPES : not_implemented u
   | CKA_TRUSTED : bool u
-  | CKA_CERTIFICATE_CATEGORY : not_implemented u
-  | CKA_JAVA_MIDP_SECURITY_DOMAIN : not_implemented u
-  | CKA_URL : not_implemented u
-  | CKA_HASH_OF_SUBJECT_PUBLIC_KEY : not_implemented u
-  | CKA_HASH_OF_ISSUER_PUBLIC_KEY : not_implemented u
   | CKA_CHECK_VALUE : not_implemented u
   | CKA_KEY_TYPE : Pkcs11_CK_KEY_TYPE.u u
   | CKA_SUBJECT : string u
@@ -51,10 +38,8 @@ type _ u =
   | CKA_COEFFICIENT : Pkcs11_CK_BIGINT.t u
   | CKA_PRIME : Pkcs11_CK_BIGINT.t u
   | CKA_SUBPRIME : Pkcs11_CK_BIGINT.t u
-  | CKA_BASE : not_implemented u
   | CKA_PRIME_BITS : Pkcs11_CK_ULONG.t u
   | CKA_SUBPRIME_BITS : Pkcs11_CK_ULONG.t u
-  | CKA_VALUE_BITS : not_implemented u
   | CKA_VALUE_LEN : Pkcs11_CK_ULONG.t u
   | CKA_EXTRACTABLE : bool u
   | CKA_LOCAL : bool u
@@ -65,45 +50,11 @@ type _ u =
   (* | CKA_ECDSA_PARAMS : string u *)
   | CKA_EC_PARAMS : Key_parsers.Asn1.EC.Params.t u
   | CKA_EC_POINT : Key_parsers.Asn1.EC.point u
-  | CKA_SECONDARY_AUTH : not_implemented u
-  | CKA_AUTH_PIN_FLAGS : not_implemented u
   | CKA_ALWAYS_AUTHENTICATE : bool u
   | CKA_WRAP_WITH_TRUSTED : bool u
   | CKA_WRAP_TEMPLATE : not_implemented u
   | CKA_UNWRAP_TEMPLATE : not_implemented u
-  | CKA_OTP_FORMAT : not_implemented u
-  | CKA_OTP_LENGTH : not_implemented u
-  | CKA_OTP_TIME_INTERVAL : not_implemented u
-  | CKA_OTP_USER_FRIENDLY_MODE : not_implemented u
-  | CKA_OTP_CHALLENGE_REQUIREMENT : not_implemented u
-  | CKA_OTP_TIME_REQUIREMENT : not_implemented u
-  | CKA_OTP_COUNTER_REQUIREMENT : not_implemented u
-  | CKA_OTP_PIN_REQUIREMENT : not_implemented u
-  | CKA_OTP_COUNTER : not_implemented u
-  | CKA_OTP_TIME : not_implemented u
-  | CKA_OTP_USER_IDENTIFIER : not_implemented u
-  | CKA_OTP_SERVICE_IDENTIFIER : not_implemented u
-  | CKA_OTP_SERVICE_LOGO : not_implemented u
-  | CKA_OTP_SERVICE_LOGO_TYPE : not_implemented u
-  | CKA_HW_FEATURE_TYPE : not_implemented u
-  | CKA_RESET_ON_INIT : not_implemented u
-  | CKA_HAS_RESET : not_implemented u
-  | CKA_PIXEL_X : not_implemented u
-  | CKA_PIXEL_Y : not_implemented u
-  | CKA_RESOLUTION : not_implemented u
-  | CKA_CHAR_ROWS : not_implemented u
-  | CKA_CHAR_COLUMNS : not_implemented u
-  | CKA_COLOR : not_implemented u
-  | CKA_BITS_PER_PIXEL : not_implemented u
-  | CKA_CHAR_SETS : not_implemented u
-  | CKA_ENCODING_METHODS : not_implemented u
-  | CKA_MIME_TYPES : not_implemented u
-  | CKA_MECHANISM_TYPE : not_implemented u
-  | CKA_REQUIRED_CMS_ATTRIBUTES : not_implemented u
-  | CKA_DEFAULT_CMS_ATTRIBUTES : not_implemented u
-  | CKA_SUPPORTED_CMS_ATTRIBUTES : not_implemented u
   | CKA_ALLOWED_MECHANISMS : not_implemented u
-  | CKA_VENDOR_DEFINED : not_implemented u
   | CKA_CS_UNKNOWN : Unsigned.ULong.t -> not_implemented u
 
 type pack = Pack : 'a u -> pack
@@ -219,21 +170,8 @@ let view (ul : t) : pack  =
   else if ul ==  _CKA_TOKEN                         then Pack CKA_TOKEN
   else if ul ==  _CKA_PRIVATE                       then Pack CKA_PRIVATE
   else if ul ==  _CKA_LABEL                         then Pack CKA_LABEL
-  else if ul ==  _CKA_APPLICATION                   then Pack CKA_APPLICATION
   else if ul ==  _CKA_VALUE                         then Pack CKA_VALUE
-  else if ul ==  _CKA_OBJECT_ID                     then Pack CKA_OBJECT_ID
-  else if ul ==  _CKA_CERTIFICATE_TYPE              then Pack CKA_CERTIFICATE_TYPE
-  else if ul ==  _CKA_ISSUER                        then Pack CKA_ISSUER
-  else if ul ==  _CKA_SERIAL_NUMBER                 then Pack CKA_SERIAL_NUMBER
-  else if ul ==  _CKA_AC_ISSUER                     then Pack CKA_AC_ISSUER
-  else if ul ==  _CKA_OWNER                         then Pack CKA_OWNER
-  else if ul ==  _CKA_ATTR_TYPES                    then Pack CKA_ATTR_TYPES
   else if ul ==  _CKA_TRUSTED                       then Pack CKA_TRUSTED
-  else if ul ==  _CKA_CERTIFICATE_CATEGORY          then Pack CKA_CERTIFICATE_CATEGORY
-  else if ul ==  _CKA_JAVA_MIDP_SECURITY_DOMAIN     then Pack CKA_JAVA_MIDP_SECURITY_DOMAIN
-  else if ul ==  _CKA_URL                           then Pack CKA_URL
-  else if ul ==  _CKA_HASH_OF_SUBJECT_PUBLIC_KEY    then Pack CKA_HASH_OF_SUBJECT_PUBLIC_KEY
-  else if ul ==  _CKA_HASH_OF_ISSUER_PUBLIC_KEY     then Pack CKA_HASH_OF_ISSUER_PUBLIC_KEY
   else if ul ==  _CKA_CHECK_VALUE                   then Pack CKA_CHECK_VALUE
   else if ul ==  _CKA_KEY_TYPE                      then Pack CKA_KEY_TYPE
   else if ul ==  _CKA_SUBJECT                       then Pack CKA_SUBJECT
@@ -261,11 +199,8 @@ let view (ul : t) : pack  =
   else if ul ==  _CKA_COEFFICIENT                   then Pack CKA_COEFFICIENT
   else if ul ==  _CKA_PRIME                         then Pack CKA_PRIME
   else if ul ==  _CKA_SUBPRIME                      then Pack CKA_SUBPRIME
-  else if ul ==  _CKA_BASE                          then Pack CKA_BASE
   else if ul ==  _CKA_PRIME_BITS                    then Pack CKA_PRIME_BITS
   else if ul ==  _CKA_SUBPRIME_BITS                 then Pack CKA_SUBPRIME_BITS
-  (* else if ul ==  _CKA_SUB_PRIME_BITS                then Pack CKA_SUB_PRIME_BITS *)
-  else if ul ==  _CKA_VALUE_BITS                    then Pack CKA_VALUE_BITS
   else if ul ==  _CKA_VALUE_LEN                     then Pack CKA_VALUE_LEN
   else if ul ==  _CKA_EXTRACTABLE                   then Pack CKA_EXTRACTABLE
   else if ul ==  _CKA_LOCAL                         then Pack CKA_LOCAL
@@ -273,48 +208,13 @@ let view (ul : t) : pack  =
   else if ul ==  _CKA_ALWAYS_SENSITIVE              then Pack CKA_ALWAYS_SENSITIVE
   else if ul ==  _CKA_KEY_GEN_MECHANISM             then Pack CKA_KEY_GEN_MECHANISM
   else if ul ==  _CKA_MODIFIABLE                    then Pack CKA_MODIFIABLE
-  (* else if ul ==  _CKA_ECDSA_PARAMS                  then Pack CKA_ECDSA_PARAMS *)
   else if ul ==  _CKA_EC_PARAMS                     then Pack CKA_EC_PARAMS
   else if ul ==  _CKA_EC_POINT                      then Pack CKA_EC_POINT
-  else if ul ==  _CKA_SECONDARY_AUTH                then Pack CKA_SECONDARY_AUTH
-  else if ul ==  _CKA_AUTH_PIN_FLAGS                then Pack CKA_AUTH_PIN_FLAGS
   else if ul ==  _CKA_ALWAYS_AUTHENTICATE           then Pack CKA_ALWAYS_AUTHENTICATE
   else if ul ==  _CKA_WRAP_WITH_TRUSTED             then Pack CKA_WRAP_WITH_TRUSTED
   else if ul ==  _CKA_WRAP_TEMPLATE                 then Pack CKA_WRAP_TEMPLATE
   else if ul ==  _CKA_UNWRAP_TEMPLATE               then Pack CKA_UNWRAP_TEMPLATE
-  else if ul ==  _CKA_OTP_FORMAT                    then Pack CKA_OTP_FORMAT
-  else if ul ==  _CKA_OTP_LENGTH                    then Pack CKA_OTP_LENGTH
-  else if ul ==  _CKA_OTP_TIME_INTERVAL             then Pack CKA_OTP_TIME_INTERVAL
-  else if ul ==  _CKA_OTP_USER_FRIENDLY_MODE        then Pack CKA_OTP_USER_FRIENDLY_MODE
-  else if ul ==  _CKA_OTP_CHALLENGE_REQUIREMENT     then Pack CKA_OTP_CHALLENGE_REQUIREMENT
-  else if ul ==  _CKA_OTP_TIME_REQUIREMENT          then Pack CKA_OTP_TIME_REQUIREMENT
-  else if ul ==  _CKA_OTP_COUNTER_REQUIREMENT       then Pack CKA_OTP_COUNTER_REQUIREMENT
-  else if ul ==  _CKA_OTP_PIN_REQUIREMENT           then Pack CKA_OTP_PIN_REQUIREMENT
-  else if ul ==  _CKA_OTP_COUNTER                   then Pack CKA_OTP_COUNTER
-  else if ul ==  _CKA_OTP_TIME                      then Pack CKA_OTP_TIME
-  else if ul ==  _CKA_OTP_USER_IDENTIFIER           then Pack CKA_OTP_USER_IDENTIFIER
-  else if ul ==  _CKA_OTP_SERVICE_IDENTIFIER        then Pack CKA_OTP_SERVICE_IDENTIFIER
-  else if ul ==  _CKA_OTP_SERVICE_LOGO              then Pack CKA_OTP_SERVICE_LOGO
-  else if ul ==  _CKA_OTP_SERVICE_LOGO_TYPE         then Pack CKA_OTP_SERVICE_LOGO_TYPE
-  else if ul ==  _CKA_HW_FEATURE_TYPE               then Pack CKA_HW_FEATURE_TYPE
-  else if ul ==  _CKA_RESET_ON_INIT                 then Pack CKA_RESET_ON_INIT
-  else if ul ==  _CKA_HAS_RESET                     then Pack CKA_HAS_RESET
-  else if ul ==  _CKA_PIXEL_X                       then Pack CKA_PIXEL_X
-  else if ul ==  _CKA_PIXEL_Y                       then Pack CKA_PIXEL_Y
-  else if ul ==  _CKA_RESOLUTION                    then Pack CKA_RESOLUTION
-  else if ul ==  _CKA_CHAR_ROWS                     then Pack CKA_CHAR_ROWS
-  else if ul ==  _CKA_CHAR_COLUMNS                  then Pack CKA_CHAR_COLUMNS
-  else if ul ==  _CKA_COLOR                         then Pack CKA_COLOR
-  else if ul ==  _CKA_BITS_PER_PIXEL                then Pack CKA_BITS_PER_PIXEL
-  else if ul ==  _CKA_CHAR_SETS                     then Pack CKA_CHAR_SETS
-  else if ul ==  _CKA_ENCODING_METHODS              then Pack CKA_ENCODING_METHODS
-  else if ul ==  _CKA_MIME_TYPES                    then Pack CKA_MIME_TYPES
-  else if ul ==  _CKA_MECHANISM_TYPE                then Pack CKA_MECHANISM_TYPE
-  else if ul ==  _CKA_REQUIRED_CMS_ATTRIBUTES       then Pack CKA_REQUIRED_CMS_ATTRIBUTES
-  else if ul ==  _CKA_DEFAULT_CMS_ATTRIBUTES        then Pack CKA_DEFAULT_CMS_ATTRIBUTES
-  else if ul ==  _CKA_SUPPORTED_CMS_ATTRIBUTES      then Pack CKA_SUPPORTED_CMS_ATTRIBUTES
   else if ul ==  _CKA_ALLOWED_MECHANISMS            then Pack CKA_ALLOWED_MECHANISMS
-  else if ul ==  _CKA_VENDOR_DEFINED                then Pack CKA_VENDOR_DEFINED
   else
     begin
       Pkcs11_log.log @@ Printf.sprintf "Unknown CKA code: 0x%Lx" @@ Int64.of_string @@ Unsigned.ULong.to_string ul;
@@ -326,21 +226,8 @@ let make (type s) (x : s u) : t = match x with
   | CKA_TOKEN -> _CKA_TOKEN
   | CKA_PRIVATE -> _CKA_PRIVATE
   | CKA_LABEL -> _CKA_LABEL
-  | CKA_APPLICATION -> _CKA_APPLICATION
   | CKA_VALUE -> _CKA_VALUE
-  | CKA_OBJECT_ID -> _CKA_OBJECT_ID
-  | CKA_CERTIFICATE_TYPE -> _CKA_CERTIFICATE_TYPE
-  | CKA_ISSUER -> _CKA_ISSUER
-  | CKA_SERIAL_NUMBER -> _CKA_SERIAL_NUMBER
-  | CKA_AC_ISSUER -> _CKA_AC_ISSUER
-  | CKA_OWNER -> _CKA_OWNER
-  | CKA_ATTR_TYPES -> _CKA_ATTR_TYPES
   | CKA_TRUSTED -> _CKA_TRUSTED
-  | CKA_CERTIFICATE_CATEGORY -> _CKA_CERTIFICATE_CATEGORY
-  | CKA_JAVA_MIDP_SECURITY_DOMAIN -> _CKA_JAVA_MIDP_SECURITY_DOMAIN
-  | CKA_URL -> _CKA_URL
-  | CKA_HASH_OF_SUBJECT_PUBLIC_KEY -> _CKA_HASH_OF_SUBJECT_PUBLIC_KEY
-  | CKA_HASH_OF_ISSUER_PUBLIC_KEY -> _CKA_HASH_OF_ISSUER_PUBLIC_KEY
   | CKA_CHECK_VALUE -> _CKA_CHECK_VALUE
   | CKA_KEY_TYPE -> _CKA_KEY_TYPE
   | CKA_SUBJECT -> _CKA_SUBJECT
@@ -368,11 +255,8 @@ let make (type s) (x : s u) : t = match x with
   | CKA_COEFFICIENT -> _CKA_COEFFICIENT
   | CKA_PRIME -> _CKA_PRIME
   | CKA_SUBPRIME -> _CKA_SUBPRIME
-  | CKA_BASE -> _CKA_BASE
   | CKA_PRIME_BITS -> _CKA_PRIME_BITS
   | CKA_SUBPRIME_BITS -> _CKA_SUBPRIME_BITS
-  (* | CKA_SUB_PRIME_BITS -> _CKA_SUB_PRIME_BITS *)
-  | CKA_VALUE_BITS -> _CKA_VALUE_BITS
   | CKA_VALUE_LEN -> _CKA_VALUE_LEN
   | CKA_EXTRACTABLE -> _CKA_EXTRACTABLE
   | CKA_LOCAL -> _CKA_LOCAL
@@ -383,45 +267,11 @@ let make (type s) (x : s u) : t = match x with
   (* | CKA_ECDSA_PARAMS -> _CKA_ECDSA_PARAMS *)
   | CKA_EC_PARAMS -> _CKA_EC_PARAMS
   | CKA_EC_POINT -> _CKA_EC_POINT
-  | CKA_SECONDARY_AUTH -> _CKA_SECONDARY_AUTH
-  | CKA_AUTH_PIN_FLAGS -> _CKA_AUTH_PIN_FLAGS
   | CKA_ALWAYS_AUTHENTICATE -> _CKA_ALWAYS_AUTHENTICATE
   | CKA_WRAP_WITH_TRUSTED -> _CKA_WRAP_WITH_TRUSTED
   | CKA_WRAP_TEMPLATE -> _CKA_WRAP_TEMPLATE
   | CKA_UNWRAP_TEMPLATE -> _CKA_UNWRAP_TEMPLATE
-  | CKA_OTP_FORMAT -> _CKA_OTP_FORMAT
-  | CKA_OTP_LENGTH -> _CKA_OTP_LENGTH
-  | CKA_OTP_TIME_INTERVAL -> _CKA_OTP_TIME_INTERVAL
-  | CKA_OTP_USER_FRIENDLY_MODE -> _CKA_OTP_USER_FRIENDLY_MODE
-  | CKA_OTP_CHALLENGE_REQUIREMENT -> _CKA_OTP_CHALLENGE_REQUIREMENT
-  | CKA_OTP_TIME_REQUIREMENT -> _CKA_OTP_TIME_REQUIREMENT
-  | CKA_OTP_COUNTER_REQUIREMENT -> _CKA_OTP_COUNTER_REQUIREMENT
-  | CKA_OTP_PIN_REQUIREMENT -> _CKA_OTP_PIN_REQUIREMENT
-  | CKA_OTP_COUNTER -> _CKA_OTP_COUNTER
-  | CKA_OTP_TIME -> _CKA_OTP_TIME
-  | CKA_OTP_USER_IDENTIFIER -> _CKA_OTP_USER_IDENTIFIER
-  | CKA_OTP_SERVICE_IDENTIFIER -> _CKA_OTP_SERVICE_IDENTIFIER
-  | CKA_OTP_SERVICE_LOGO -> _CKA_OTP_SERVICE_LOGO
-  | CKA_OTP_SERVICE_LOGO_TYPE -> _CKA_OTP_SERVICE_LOGO_TYPE
-  | CKA_HW_FEATURE_TYPE -> _CKA_HW_FEATURE_TYPE
-  | CKA_RESET_ON_INIT -> _CKA_RESET_ON_INIT
-  | CKA_HAS_RESET -> _CKA_HAS_RESET
-  | CKA_PIXEL_X -> _CKA_PIXEL_X
-  | CKA_PIXEL_Y -> _CKA_PIXEL_Y
-  | CKA_RESOLUTION -> _CKA_RESOLUTION
-  | CKA_CHAR_ROWS -> _CKA_CHAR_ROWS
-  | CKA_CHAR_COLUMNS -> _CKA_CHAR_COLUMNS
-  | CKA_COLOR -> _CKA_COLOR
-  | CKA_BITS_PER_PIXEL -> _CKA_BITS_PER_PIXEL
-  | CKA_CHAR_SETS -> _CKA_CHAR_SETS
-  | CKA_ENCODING_METHODS -> _CKA_ENCODING_METHODS
-  | CKA_MIME_TYPES -> _CKA_MIME_TYPES
-  | CKA_MECHANISM_TYPE -> _CKA_MECHANISM_TYPE
-  | CKA_REQUIRED_CMS_ATTRIBUTES -> _CKA_REQUIRED_CMS_ATTRIBUTES
-  | CKA_DEFAULT_CMS_ATTRIBUTES -> _CKA_DEFAULT_CMS_ATTRIBUTES
-  | CKA_SUPPORTED_CMS_ATTRIBUTES -> _CKA_SUPPORTED_CMS_ATTRIBUTES
   | CKA_ALLOWED_MECHANISMS -> _CKA_ALLOWED_MECHANISMS
-  | CKA_VENDOR_DEFINED -> _CKA_VENDOR_DEFINED
   | CKA_CS_UNKNOWN ul -> ul
 
   let to_string : type a . a u -> string = function
@@ -429,21 +279,8 @@ let make (type s) (x : s u) : t = match x with
   | CKA_TOKEN -> "CKA_TOKEN"
   | CKA_PRIVATE -> "CKA_PRIVATE"
   | CKA_LABEL -> "CKA_LABEL"
-  | CKA_APPLICATION -> "CKA_APPLICATION"
   | CKA_VALUE -> "CKA_VALUE"
-  | CKA_OBJECT_ID -> "CKA_OBJECT_ID"
-  | CKA_CERTIFICATE_TYPE -> "CKA_CERTIFICATE_TYPE"
-  | CKA_ISSUER -> "CKA_ISSUER"
-  | CKA_SERIAL_NUMBER -> "CKA_SERIAL_NUMBER"
-  | CKA_AC_ISSUER -> "CKA_AC_ISSUER"
-  | CKA_OWNER -> "CKA_OWNER"
-  | CKA_ATTR_TYPES -> "CKA_ATTR_TYPES"
   | CKA_TRUSTED -> "CKA_TRUSTED"
-  | CKA_CERTIFICATE_CATEGORY -> "CKA_CERTIFICATE_CATEGORY"
-  | CKA_JAVA_MIDP_SECURITY_DOMAIN -> "CKA_JAVA_MIDP_SECURITY_DOMAIN"
-  | CKA_URL -> "CKA_URL"
-  | CKA_HASH_OF_SUBJECT_PUBLIC_KEY -> "CKA_HASH_OF_SUBJECT_PUBLIC_KEY"
-  | CKA_HASH_OF_ISSUER_PUBLIC_KEY -> "CKA_HASH_OF_ISSUER_PUBLIC_KEY"
   | CKA_CHECK_VALUE -> "CKA_CHECK_VALUE"
   | CKA_KEY_TYPE -> "CKA_KEY_TYPE"
   | CKA_SUBJECT -> "CKA_SUBJECT"
@@ -471,11 +308,8 @@ let make (type s) (x : s u) : t = match x with
   | CKA_COEFFICIENT -> "CKA_COEFFICIENT"
   | CKA_PRIME -> "CKA_PRIME"
   | CKA_SUBPRIME -> "CKA_SUBPRIME"
-  | CKA_BASE -> "CKA_BASE"
   | CKA_PRIME_BITS -> "CKA_PRIME_BITS"
   | CKA_SUBPRIME_BITS -> "CKA_SUBPRIME_BITS"
-  (* | CKA_SUB_PRIME_BITS -> "CKA_SUB_PRIME_BITS" *)
-  | CKA_VALUE_BITS -> "CKA_VALUE_BITS"
   | CKA_VALUE_LEN -> "CKA_VALUE_LEN"
   | CKA_EXTRACTABLE -> "CKA_EXTRACTABLE"
   | CKA_LOCAL -> "CKA_LOCAL"
@@ -486,45 +320,11 @@ let make (type s) (x : s u) : t = match x with
   (* | CKA_ECDSA_PARAMS -> "CKA_ECDSA_PARAMS" *)
   | CKA_EC_PARAMS -> "CKA_EC_PARAMS"
   | CKA_EC_POINT -> "CKA_EC_POINT"
-  | CKA_SECONDARY_AUTH -> "CKA_SECONDARY_AUTH"
-  | CKA_AUTH_PIN_FLAGS -> "CKA_AUTH_PIN_FLAGS"
   | CKA_ALWAYS_AUTHENTICATE -> "CKA_ALWAYS_AUTHENTICATE"
   | CKA_WRAP_WITH_TRUSTED -> "CKA_WRAP_WITH_TRUSTED"
   | CKA_WRAP_TEMPLATE -> "CKA_WRAP_TEMPLATE"
   | CKA_UNWRAP_TEMPLATE -> "CKA_UNWRAP_TEMPLATE"
-  | CKA_OTP_FORMAT -> "CKA_OTP_FORMAT"
-  | CKA_OTP_LENGTH -> "CKA_OTP_LENGTH"
-  | CKA_OTP_TIME_INTERVAL -> "CKA_OTP_TIME_INTERVAL"
-  | CKA_OTP_USER_FRIENDLY_MODE -> "CKA_OTP_USER_FRIENDLY_MODE"
-  | CKA_OTP_CHALLENGE_REQUIREMENT -> "CKA_OTP_CHALLENGE_REQUIREMENT"
-  | CKA_OTP_TIME_REQUIREMENT -> "CKA_OTP_TIME_REQUIREMENT"
-  | CKA_OTP_COUNTER_REQUIREMENT -> "CKA_OTP_COUNTER_REQUIREMENT"
-  | CKA_OTP_PIN_REQUIREMENT -> "CKA_OTP_PIN_REQUIREMENT"
-  | CKA_OTP_COUNTER -> "CKA_OTP_COUNTER"
-  | CKA_OTP_TIME -> "CKA_OTP_TIME"
-  | CKA_OTP_USER_IDENTIFIER -> "CKA_OTP_USER_IDENTIFIER"
-  | CKA_OTP_SERVICE_IDENTIFIER -> "CKA_OTP_SERVICE_IDENTIFIER"
-  | CKA_OTP_SERVICE_LOGO -> "CKA_OTP_SERVICE_LOGO"
-  | CKA_OTP_SERVICE_LOGO_TYPE -> "CKA_OTP_SERVICE_LOGO_TYPE"
-  | CKA_HW_FEATURE_TYPE -> "CKA_HW_FEATURE_TYPE"
-  | CKA_RESET_ON_INIT -> "CKA_RESET_ON_INIT"
-  | CKA_HAS_RESET -> "CKA_HAS_RESET"
-  | CKA_PIXEL_X -> "CKA_PIXEL_X"
-  | CKA_PIXEL_Y -> "CKA_PIXEL_Y"
-  | CKA_RESOLUTION -> "CKA_RESOLUTION"
-  | CKA_CHAR_ROWS -> "CKA_CHAR_ROWS"
-  | CKA_CHAR_COLUMNS -> "CKA_CHAR_COLUMNS"
-  | CKA_COLOR -> "CKA_COLOR"
-  | CKA_BITS_PER_PIXEL -> "CKA_BITS_PER_PIXEL"
-  | CKA_CHAR_SETS -> "CKA_CHAR_SETS"
-  | CKA_ENCODING_METHODS -> "CKA_ENCODING_METHODS"
-  | CKA_MIME_TYPES -> "CKA_MIME_TYPES"
-  | CKA_MECHANISM_TYPE -> "CKA_MECHANISM_TYPE"
-  | CKA_REQUIRED_CMS_ATTRIBUTES -> "CKA_REQUIRED_CMS_ATTRIBUTES"
-  | CKA_DEFAULT_CMS_ATTRIBUTES -> "CKA_DEFAULT_CMS_ATTRIBUTES"
-  | CKA_SUPPORTED_CMS_ATTRIBUTES -> "CKA_SUPPORTED_CMS_ATTRIBUTES"
   | CKA_ALLOWED_MECHANISMS -> "CKA_ALLOWED_MECHANISMS"
-  | CKA_VENDOR_DEFINED -> "CKA_VENDOR_DEFINED"
   | CKA_CS_UNKNOWN ul -> Unsigned.ULong.to_string ul
 
 let of_string = function
@@ -532,21 +332,8 @@ let of_string = function
   | "CKA_TOKEN" -> Pack CKA_TOKEN
   | "CKA_PRIVATE" -> Pack CKA_PRIVATE
   | "CKA_LABEL" -> Pack CKA_LABEL
-  | "CKA_APPLICATION" -> Pack CKA_APPLICATION
   | "CKA_VALUE" -> Pack CKA_VALUE
-  | "CKA_OBJECT_ID" -> Pack CKA_OBJECT_ID
-  | "CKA_CERTIFICATE_TYPE" -> Pack CKA_CERTIFICATE_TYPE
-  | "CKA_ISSUER" -> Pack CKA_ISSUER
-  | "CKA_SERIAL_NUMBER" -> Pack CKA_SERIAL_NUMBER
-  | "CKA_AC_ISSUER" -> Pack CKA_AC_ISSUER
-  | "CKA_OWNER" -> Pack CKA_OWNER
-  | "CKA_ATTR_TYPES" -> Pack CKA_ATTR_TYPES
   | "CKA_TRUSTED" -> Pack CKA_TRUSTED
-  | "CKA_CERTIFICATE_CATEGORY" -> Pack CKA_CERTIFICATE_CATEGORY
-  | "CKA_JAVA_MIDP_SECURITY_DOMAIN" -> Pack CKA_JAVA_MIDP_SECURITY_DOMAIN
-  | "CKA_URL" -> Pack CKA_URL
-  | "CKA_HASH_OF_SUBJECT_PUBLIC_KEY" -> Pack CKA_HASH_OF_SUBJECT_PUBLIC_KEY
-  | "CKA_HASH_OF_ISSUER_PUBLIC_KEY" -> Pack CKA_HASH_OF_ISSUER_PUBLIC_KEY
   | "CKA_CHECK_VALUE" -> Pack CKA_CHECK_VALUE
   | "CKA_KEY_TYPE" -> Pack CKA_KEY_TYPE
   | "CKA_SUBJECT" -> Pack CKA_SUBJECT
@@ -574,11 +361,9 @@ let of_string = function
   | "CKA_COEFFICIENT" -> Pack CKA_COEFFICIENT
   | "CKA_PRIME" -> Pack CKA_PRIME
   | "CKA_SUBPRIME" -> Pack CKA_SUBPRIME
-  | "CKA_BASE" -> Pack CKA_BASE
   | "CKA_PRIME_BITS" -> Pack CKA_PRIME_BITS
   | "CKA_SUBPRIME_BITS" -> Pack CKA_SUBPRIME_BITS
   | "CKA_SUB_PRIME_BITS" -> Pack CKA_SUBPRIME_BITS
-  | "CKA_VALUE_BITS" -> Pack CKA_VALUE_BITS
   | "CKA_VALUE_LEN" -> Pack CKA_VALUE_LEN
   | "CKA_EXTRACTABLE" -> Pack CKA_EXTRACTABLE
   | "CKA_LOCAL" -> Pack CKA_LOCAL
@@ -589,45 +374,11 @@ let of_string = function
   | "CKA_ECDSA_PARAMS" -> Pack CKA_EC_PARAMS
   | "CKA_EC_PARAMS" -> Pack CKA_EC_PARAMS
   | "CKA_EC_POINT" -> Pack CKA_EC_POINT
-  | "CKA_SECONDARY_AUTH" -> Pack CKA_SECONDARY_AUTH
-  | "CKA_AUTH_PIN_FLAGS" -> Pack CKA_AUTH_PIN_FLAGS
   | "CKA_ALWAYS_AUTHENTICATE" -> Pack CKA_ALWAYS_AUTHENTICATE
   | "CKA_WRAP_WITH_TRUSTED" -> Pack CKA_WRAP_WITH_TRUSTED
   | "CKA_WRAP_TEMPLATE" -> Pack CKA_WRAP_TEMPLATE
   | "CKA_UNWRAP_TEMPLATE" -> Pack CKA_UNWRAP_TEMPLATE
-  | "CKA_OTP_FORMAT" -> Pack CKA_OTP_FORMAT
-  | "CKA_OTP_LENGTH" -> Pack CKA_OTP_LENGTH
-  | "CKA_OTP_TIME_INTERVAL" -> Pack CKA_OTP_TIME_INTERVAL
-  | "CKA_OTP_USER_FRIENDLY_MODE" -> Pack CKA_OTP_USER_FRIENDLY_MODE
-  | "CKA_OTP_CHALLENGE_REQUIREMENT" -> Pack CKA_OTP_CHALLENGE_REQUIREMENT
-  | "CKA_OTP_TIME_REQUIREMENT" -> Pack CKA_OTP_TIME_REQUIREMENT
-  | "CKA_OTP_COUNTER_REQUIREMENT" -> Pack CKA_OTP_COUNTER_REQUIREMENT
-  | "CKA_OTP_PIN_REQUIREMENT" -> Pack CKA_OTP_PIN_REQUIREMENT
-  | "CKA_OTP_COUNTER" -> Pack CKA_OTP_COUNTER
-  | "CKA_OTP_TIME" -> Pack CKA_OTP_TIME
-  | "CKA_OTP_USER_IDENTIFIER" -> Pack CKA_OTP_USER_IDENTIFIER
-  | "CKA_OTP_SERVICE_IDENTIFIER" -> Pack CKA_OTP_SERVICE_IDENTIFIER
-  | "CKA_OTP_SERVICE_LOGO" -> Pack CKA_OTP_SERVICE_LOGO
-  | "CKA_OTP_SERVICE_LOGO_TYPE" -> Pack CKA_OTP_SERVICE_LOGO_TYPE
-  | "CKA_HW_FEATURE_TYPE" -> Pack CKA_HW_FEATURE_TYPE
-  | "CKA_RESET_ON_INIT" -> Pack CKA_RESET_ON_INIT
-  | "CKA_HAS_RESET" -> Pack CKA_HAS_RESET
-  | "CKA_PIXEL_X" -> Pack CKA_PIXEL_X
-  | "CKA_PIXEL_Y" -> Pack CKA_PIXEL_Y
-  | "CKA_RESOLUTION" -> Pack CKA_RESOLUTION
-  | "CKA_CHAR_ROWS" -> Pack CKA_CHAR_ROWS
-  | "CKA_CHAR_COLUMNS" -> Pack CKA_CHAR_COLUMNS
-  | "CKA_COLOR" -> Pack CKA_COLOR
-  | "CKA_BITS_PER_PIXEL" -> Pack CKA_BITS_PER_PIXEL
-  | "CKA_CHAR_SETS" -> Pack CKA_CHAR_SETS
-  | "CKA_ENCODING_METHODS" -> Pack CKA_ENCODING_METHODS
-  | "CKA_MIME_TYPES" -> Pack CKA_MIME_TYPES
-  | "CKA_MECHANISM_TYPE" -> Pack CKA_MECHANISM_TYPE
-  | "CKA_REQUIRED_CMS_ATTRIBUTES" -> Pack CKA_REQUIRED_CMS_ATTRIBUTES
-  | "CKA_DEFAULT_CMS_ATTRIBUTES" -> Pack CKA_DEFAULT_CMS_ATTRIBUTES
-  | "CKA_SUPPORTED_CMS_ATTRIBUTES" -> Pack CKA_SUPPORTED_CMS_ATTRIBUTES
   | "CKA_ALLOWED_MECHANISMS" -> Pack CKA_ALLOWED_MECHANISMS
-  | "CKA_VENDOR_DEFINED" -> Pack CKA_VENDOR_DEFINED
   | s ->
       try
         Pack (CKA_CS_UNKNOWN (Unsigned.ULong.of_string s))
@@ -653,21 +404,8 @@ let compare' : type a b . a u -> b u -> (a,b) comparison = fun a b ->
   | CKA_TOKEN, CKA_TOKEN -> Equal
   | CKA_PRIVATE, CKA_PRIVATE -> Equal
   | CKA_LABEL, CKA_LABEL -> Equal
-  | CKA_APPLICATION, CKA_APPLICATION -> Equal
   | CKA_VALUE, CKA_VALUE -> Equal
-  | CKA_OBJECT_ID, CKA_OBJECT_ID -> Equal
-  | CKA_CERTIFICATE_TYPE, CKA_CERTIFICATE_TYPE -> Equal
-  | CKA_ISSUER, CKA_ISSUER -> Equal
-  | CKA_SERIAL_NUMBER, CKA_SERIAL_NUMBER -> Equal
-  | CKA_AC_ISSUER, CKA_AC_ISSUER -> Equal
-  | CKA_OWNER, CKA_OWNER -> Equal
-  | CKA_ATTR_TYPES, CKA_ATTR_TYPES -> Equal
   | CKA_TRUSTED, CKA_TRUSTED -> Equal
-  | CKA_CERTIFICATE_CATEGORY, CKA_CERTIFICATE_CATEGORY -> Equal
-  | CKA_JAVA_MIDP_SECURITY_DOMAIN, CKA_JAVA_MIDP_SECURITY_DOMAIN -> Equal
-  | CKA_URL, CKA_URL -> Equal
-  | CKA_HASH_OF_SUBJECT_PUBLIC_KEY, CKA_HASH_OF_SUBJECT_PUBLIC_KEY -> Equal
-  | CKA_HASH_OF_ISSUER_PUBLIC_KEY, CKA_HASH_OF_ISSUER_PUBLIC_KEY -> Equal
   | CKA_CHECK_VALUE, CKA_CHECK_VALUE -> Equal
   | CKA_KEY_TYPE, CKA_KEY_TYPE -> Equal
   | CKA_SUBJECT, CKA_SUBJECT -> Equal
@@ -695,11 +433,8 @@ let compare' : type a b . a u -> b u -> (a,b) comparison = fun a b ->
   | CKA_COEFFICIENT, CKA_COEFFICIENT -> Equal
   | CKA_PRIME, CKA_PRIME -> Equal
   | CKA_SUBPRIME, CKA_SUBPRIME -> Equal
-  | CKA_BASE, CKA_BASE -> Equal
   | CKA_PRIME_BITS, CKA_PRIME_BITS -> Equal
   | CKA_SUBPRIME_BITS, CKA_SUBPRIME_BITS -> Equal
-  (* | CKA_SUB_PRIME_BITS, CKA_SUB_PRIME_BITS -> Equal *)
-  | CKA_VALUE_BITS, CKA_VALUE_BITS -> Equal
   | CKA_VALUE_LEN, CKA_VALUE_LEN -> Equal
   | CKA_EXTRACTABLE, CKA_EXTRACTABLE -> Equal
   | CKA_LOCAL, CKA_LOCAL -> Equal
@@ -707,48 +442,13 @@ let compare' : type a b . a u -> b u -> (a,b) comparison = fun a b ->
   | CKA_ALWAYS_SENSITIVE, CKA_ALWAYS_SENSITIVE -> Equal
   | CKA_KEY_GEN_MECHANISM, CKA_KEY_GEN_MECHANISM -> Equal
   | CKA_MODIFIABLE, CKA_MODIFIABLE -> Equal
-  (* | CKA_ECDSA_PARAMS, CKA_ECDSA_PARAMS -> Equal *)
   | CKA_EC_PARAMS, CKA_EC_PARAMS -> Equal
   | CKA_EC_POINT, CKA_EC_POINT -> Equal
-  | CKA_SECONDARY_AUTH, CKA_SECONDARY_AUTH -> Equal
-  | CKA_AUTH_PIN_FLAGS, CKA_AUTH_PIN_FLAGS -> Equal
   | CKA_ALWAYS_AUTHENTICATE, CKA_ALWAYS_AUTHENTICATE -> Equal
   | CKA_WRAP_WITH_TRUSTED, CKA_WRAP_WITH_TRUSTED -> Equal
   | CKA_WRAP_TEMPLATE, CKA_WRAP_TEMPLATE -> Equal
   | CKA_UNWRAP_TEMPLATE, CKA_UNWRAP_TEMPLATE -> Equal
-  | CKA_OTP_FORMAT, CKA_OTP_FORMAT -> Equal
-  | CKA_OTP_LENGTH, CKA_OTP_LENGTH -> Equal
-  | CKA_OTP_TIME_INTERVAL, CKA_OTP_TIME_INTERVAL -> Equal
-  | CKA_OTP_USER_FRIENDLY_MODE, CKA_OTP_USER_FRIENDLY_MODE -> Equal
-  | CKA_OTP_CHALLENGE_REQUIREMENT, CKA_OTP_CHALLENGE_REQUIREMENT -> Equal
-  | CKA_OTP_TIME_REQUIREMENT, CKA_OTP_TIME_REQUIREMENT -> Equal
-  | CKA_OTP_COUNTER_REQUIREMENT, CKA_OTP_COUNTER_REQUIREMENT -> Equal
-  | CKA_OTP_PIN_REQUIREMENT, CKA_OTP_PIN_REQUIREMENT -> Equal
-  | CKA_OTP_COUNTER, CKA_OTP_COUNTER -> Equal
-  | CKA_OTP_TIME, CKA_OTP_TIME -> Equal
-  | CKA_OTP_USER_IDENTIFIER, CKA_OTP_USER_IDENTIFIER -> Equal
-  | CKA_OTP_SERVICE_IDENTIFIER, CKA_OTP_SERVICE_IDENTIFIER -> Equal
-  | CKA_OTP_SERVICE_LOGO, CKA_OTP_SERVICE_LOGO -> Equal
-  | CKA_OTP_SERVICE_LOGO_TYPE, CKA_OTP_SERVICE_LOGO_TYPE -> Equal
-  | CKA_HW_FEATURE_TYPE, CKA_HW_FEATURE_TYPE -> Equal
-  | CKA_RESET_ON_INIT, CKA_RESET_ON_INIT -> Equal
-  | CKA_HAS_RESET, CKA_HAS_RESET -> Equal
-  | CKA_PIXEL_X, CKA_PIXEL_X -> Equal
-  | CKA_PIXEL_Y, CKA_PIXEL_Y -> Equal
-  | CKA_RESOLUTION, CKA_RESOLUTION -> Equal
-  | CKA_CHAR_ROWS, CKA_CHAR_ROWS -> Equal
-  | CKA_CHAR_COLUMNS, CKA_CHAR_COLUMNS -> Equal
-  | CKA_COLOR, CKA_COLOR -> Equal
-  | CKA_BITS_PER_PIXEL, CKA_BITS_PER_PIXEL -> Equal
-  | CKA_CHAR_SETS, CKA_CHAR_SETS -> Equal
-  | CKA_ENCODING_METHODS, CKA_ENCODING_METHODS -> Equal
-  | CKA_MIME_TYPES, CKA_MIME_TYPES -> Equal
-  | CKA_MECHANISM_TYPE, CKA_MECHANISM_TYPE -> Equal
-  | CKA_REQUIRED_CMS_ATTRIBUTES, CKA_REQUIRED_CMS_ATTRIBUTES -> Equal
-  | CKA_DEFAULT_CMS_ATTRIBUTES, CKA_DEFAULT_CMS_ATTRIBUTES -> Equal
-  | CKA_SUPPORTED_CMS_ATTRIBUTES, CKA_SUPPORTED_CMS_ATTRIBUTES -> Equal
   | CKA_ALLOWED_MECHANISMS, CKA_ALLOWED_MECHANISMS -> Equal
-  | CKA_VENDOR_DEFINED, CKA_VENDOR_DEFINED -> Equal
   | CKA_CS_UNKNOWN ul1, CKA_CS_UNKNOWN ul2 ->
       let cmp = Unsigned.ULong.compare ul1 ul2 in
       if cmp = 0
@@ -760,21 +460,8 @@ let compare' : type a b . a u -> b u -> (a,b) comparison = fun a b ->
   | CKA_TOKEN, _ -> assert false
   | CKA_PRIVATE, _ -> assert false
   | CKA_LABEL, _ -> assert false
-  | CKA_APPLICATION, _ -> assert false
   | CKA_VALUE, _ -> assert false
-  | CKA_OBJECT_ID, _ -> assert false
-  | CKA_CERTIFICATE_TYPE, _ -> assert false
-  | CKA_ISSUER, _ -> assert false
-  | CKA_SERIAL_NUMBER, _ -> assert false
-  | CKA_AC_ISSUER, _ -> assert false
-  | CKA_OWNER, _ -> assert false
-  | CKA_ATTR_TYPES, _ -> assert false
   | CKA_TRUSTED, _ -> assert false
-  | CKA_CERTIFICATE_CATEGORY, _ -> assert false
-  | CKA_JAVA_MIDP_SECURITY_DOMAIN, _ -> assert false
-  | CKA_URL, _ -> assert false
-  | CKA_HASH_OF_SUBJECT_PUBLIC_KEY, _ -> assert false
-  | CKA_HASH_OF_ISSUER_PUBLIC_KEY, _ -> assert false
   | CKA_CHECK_VALUE, _ -> assert false
   | CKA_KEY_TYPE, _ -> assert false
   | CKA_SUBJECT, _ -> assert false
@@ -802,11 +489,8 @@ let compare' : type a b . a u -> b u -> (a,b) comparison = fun a b ->
   | CKA_COEFFICIENT, _ -> assert false
   | CKA_PRIME, _ -> assert false
   | CKA_SUBPRIME, _ -> assert false
-  | CKA_BASE, _ -> assert false
   | CKA_PRIME_BITS, _ -> assert false
   | CKA_SUBPRIME_BITS, _ -> assert false
-  (* | CKA_SUB_PRIME_BITS, _ -> assert false *)
-  | CKA_VALUE_BITS, _ -> assert false
   | CKA_VALUE_LEN, _ -> assert false
   | CKA_EXTRACTABLE, _ -> assert false
   | CKA_LOCAL, _ -> assert false
@@ -817,46 +501,11 @@ let compare' : type a b . a u -> b u -> (a,b) comparison = fun a b ->
   (* | CKA_ECDSA_PARAMS, _ -> assert false *)
   | CKA_EC_PARAMS, _ -> assert false
   | CKA_EC_POINT, _ -> assert false
-  | CKA_SECONDARY_AUTH, _ -> assert false
-  | CKA_AUTH_PIN_FLAGS, _ -> assert false
   | CKA_ALWAYS_AUTHENTICATE, _ -> assert false
   | CKA_WRAP_WITH_TRUSTED, _ -> assert false
   | CKA_WRAP_TEMPLATE, _ -> assert false
   | CKA_UNWRAP_TEMPLATE, _ -> assert false
-  | CKA_OTP_FORMAT, _ -> assert false
-  | CKA_OTP_LENGTH, _ -> assert false
-  | CKA_OTP_TIME_INTERVAL, _ -> assert false
-  | CKA_OTP_USER_FRIENDLY_MODE, _ -> assert false
-  | CKA_OTP_CHALLENGE_REQUIREMENT, _ -> assert false
-  | CKA_OTP_TIME_REQUIREMENT, _ -> assert false
-  | CKA_OTP_COUNTER_REQUIREMENT, _ -> assert false
-  | CKA_OTP_PIN_REQUIREMENT, _ -> assert false
-  | CKA_OTP_COUNTER, _ -> assert false
-  | CKA_OTP_TIME, _ -> assert false
-  | CKA_OTP_USER_IDENTIFIER, _ -> assert false
-  | CKA_OTP_SERVICE_IDENTIFIER, _ -> assert false
-  | CKA_OTP_SERVICE_LOGO, _ -> assert false
-  | CKA_OTP_SERVICE_LOGO_TYPE, _ -> assert false
-  | CKA_HW_FEATURE_TYPE, _ -> assert false
-  | CKA_RESET_ON_INIT, _ -> assert false
-  | CKA_HAS_RESET, _ -> assert false
-  | CKA_PIXEL_X, _ -> assert false
-  | CKA_PIXEL_Y, _ -> assert false
-  | CKA_RESOLUTION, _ -> assert false
-  | CKA_CHAR_ROWS, _ -> assert false
-  | CKA_CHAR_COLUMNS, _ -> assert false
-  | CKA_COLOR, _ -> assert false
-  | CKA_BITS_PER_PIXEL, _ -> assert false
-  | CKA_CHAR_SETS, _ -> assert false
-  | CKA_ENCODING_METHODS, _ -> assert false
-  | CKA_MIME_TYPES, _ -> assert false
-  | CKA_MECHANISM_TYPE, _ -> assert false
-  | CKA_REQUIRED_CMS_ATTRIBUTES, _ -> assert false
-  | CKA_DEFAULT_CMS_ATTRIBUTES, _ -> assert false
-  | CKA_SUPPORTED_CMS_ATTRIBUTES, _ -> assert false
   | CKA_ALLOWED_MECHANISMS, _ -> assert false
-  | CKA_VENDOR_DEFINED, _ -> assert false
-  | CKA_CS_UNKNOWN _, _ -> assert false
 
 let compare a b =
   let a = make a

--- a/src/pkcs11_CK_ATTRIBUTE_TYPE.mli
+++ b/src/pkcs11_CK_ATTRIBUTE_TYPE.mli
@@ -9,21 +9,8 @@ type _ u =
   | CKA_TOKEN : bool u
   | CKA_PRIVATE : bool u
   | CKA_LABEL : string u
-  | CKA_APPLICATION : not_implemented u
   | CKA_VALUE : string u
-  | CKA_OBJECT_ID : not_implemented u
-  | CKA_CERTIFICATE_TYPE : not_implemented u
-  | CKA_ISSUER : not_implemented u
-  | CKA_SERIAL_NUMBER : not_implemented u
-  | CKA_AC_ISSUER : not_implemented u
-  | CKA_OWNER : not_implemented u
-  | CKA_ATTR_TYPES : not_implemented u
   | CKA_TRUSTED : bool u
-  | CKA_CERTIFICATE_CATEGORY : not_implemented u
-  | CKA_JAVA_MIDP_SECURITY_DOMAIN : not_implemented u
-  | CKA_URL : not_implemented u
-  | CKA_HASH_OF_SUBJECT_PUBLIC_KEY : not_implemented u
-  | CKA_HASH_OF_ISSUER_PUBLIC_KEY : not_implemented u
   | CKA_CHECK_VALUE : not_implemented u
   | CKA_KEY_TYPE : Pkcs11_CK_KEY_TYPE.u u
   | CKA_SUBJECT : string u
@@ -51,11 +38,8 @@ type _ u =
   | CKA_COEFFICIENT : Pkcs11_CK_BIGINT.t u
   | CKA_PRIME : Pkcs11_CK_BIGINT.t u
   | CKA_SUBPRIME : Pkcs11_CK_BIGINT.t u
-  | CKA_BASE : not_implemented u
   | CKA_PRIME_BITS : Pkcs11_CK_ULONG.t u
   | CKA_SUBPRIME_BITS : Pkcs11_CK_ULONG.t u
-  (* | CKA_SUB_PRIME_BITS : not_implemented u *)
-  | CKA_VALUE_BITS : not_implemented u
   | CKA_VALUE_LEN : Pkcs11_CK_ULONG.t u
   | CKA_EXTRACTABLE : bool u
   | CKA_LOCAL : bool u
@@ -63,48 +47,13 @@ type _ u =
   | CKA_ALWAYS_SENSITIVE : bool u
   | CKA_KEY_GEN_MECHANISM : Pkcs11_key_gen_mechanism.u u
   | CKA_MODIFIABLE : bool u
-  (* | CKA_ECDSA_PARAMS : string u *)
   | CKA_EC_PARAMS : Key_parsers.Asn1.EC.Params.t u
   | CKA_EC_POINT : Key_parsers.Asn1.EC.point u
-  | CKA_SECONDARY_AUTH : not_implemented u
-  | CKA_AUTH_PIN_FLAGS : not_implemented u
   | CKA_ALWAYS_AUTHENTICATE : bool u
   | CKA_WRAP_WITH_TRUSTED : bool u
   | CKA_WRAP_TEMPLATE : not_implemented u
   | CKA_UNWRAP_TEMPLATE : not_implemented u
-  | CKA_OTP_FORMAT : not_implemented u
-  | CKA_OTP_LENGTH : not_implemented u
-  | CKA_OTP_TIME_INTERVAL : not_implemented u
-  | CKA_OTP_USER_FRIENDLY_MODE : not_implemented u
-  | CKA_OTP_CHALLENGE_REQUIREMENT : not_implemented u
-  | CKA_OTP_TIME_REQUIREMENT : not_implemented u
-  | CKA_OTP_COUNTER_REQUIREMENT : not_implemented u
-  | CKA_OTP_PIN_REQUIREMENT : not_implemented u
-  | CKA_OTP_COUNTER : not_implemented u
-  | CKA_OTP_TIME : not_implemented u
-  | CKA_OTP_USER_IDENTIFIER : not_implemented u
-  | CKA_OTP_SERVICE_IDENTIFIER : not_implemented u
-  | CKA_OTP_SERVICE_LOGO : not_implemented u
-  | CKA_OTP_SERVICE_LOGO_TYPE : not_implemented u
-  | CKA_HW_FEATURE_TYPE : not_implemented u
-  | CKA_RESET_ON_INIT : not_implemented u
-  | CKA_HAS_RESET : not_implemented u
-  | CKA_PIXEL_X : not_implemented u
-  | CKA_PIXEL_Y : not_implemented u
-  | CKA_RESOLUTION : not_implemented u
-  | CKA_CHAR_ROWS : not_implemented u
-  | CKA_CHAR_COLUMNS : not_implemented u
-  | CKA_COLOR : not_implemented u
-  | CKA_BITS_PER_PIXEL : not_implemented u
-  | CKA_CHAR_SETS : not_implemented u
-  | CKA_ENCODING_METHODS : not_implemented u
-  | CKA_MIME_TYPES : not_implemented u
-  | CKA_MECHANISM_TYPE : not_implemented u
-  | CKA_REQUIRED_CMS_ATTRIBUTES : not_implemented u
-  | CKA_DEFAULT_CMS_ATTRIBUTES : not_implemented u
-  | CKA_SUPPORTED_CMS_ATTRIBUTES : not_implemented u
   | CKA_ALLOWED_MECHANISMS : not_implemented u
-  | CKA_VENDOR_DEFINED : not_implemented u
   | CKA_CS_UNKNOWN : Unsigned.ULong.t -> not_implemented u
 
 type pack = Pack : 'a u -> pack


### PR DESCRIPTION
Most of those were never implemented, as their name says.

There a couple decisions to take:

- `_CKA` values: those are just ints, so it does not hurt to keep them.
  They do not require long `match` expressions

- `CKA_VENDOR_DEFINED` is supposed to be the start of vendor values, not
  a precise value. These will be displayed as unknown.

- `CKA_ALLOWED_MECHANISMS`, `CKA_CHECK_VALUE`, `CKA_END_DATE`,
  `CKA_START_DATE`, `CKA_WRAP_TEMPLATE` and `CKA_UNWRAP_TEMPLATE` are
  used in `P11_key_attributes`, so they are kept.