### PR TITLE
Do not use the result module explicitly

### DIFF
--- a/_tags
+++ b/_tags
@@ -4,6 +4,7 @@ true: package(hex)
 true: package(key-parsers)
 true: package(ppx_deriving.std)
 true: package(ppx_deriving_yojson)
+true: open(Result)
 <src>: include
 <include>: include
 <src/*>: depend(include/pkcs11.h)

--- a/src/p11.mli
+++ b/src/p11.mli
@@ -1089,7 +1089,7 @@ sig
   val initialize : unit -> unit
   val finalize : unit -> unit
   val get_info : unit -> Info.t
-  val get_slot: Slot.t -> (Slot_id.t, string) Result.result
+  val get_slot: Slot.t -> (Slot_id.t, string) result
   val get_slot_list : bool -> Slot_id.t list
   val get_slot_info : slot: Slot_id.t -> Slot_info.t
   val get_token_info : slot: Slot_id.t -> Token_info.t

--- a/src/pkcs11_CK_ATTRIBUTE.ml
+++ b/src/pkcs11_CK_ATTRIBUTE.ml
@@ -30,7 +30,6 @@
 
 open Ctypes
 open Ctypes_helpers
-open Result
 
 type _t
 type t = _t structure

--- a/src/pkcs11_hex_data.ml
+++ b/src/pkcs11_hex_data.ml
@@ -27,7 +27,7 @@ exception Invalid_hex
 
 let of_yojson =
   let err msg =
-    Result.Error ("Pkcs11_hex_data: " ^ msg)
+    Error ("Pkcs11_hex_data: " ^ msg)
   in
   function
     | `String s when s.[0] = '0' && s.[1] = 'x' ->
@@ -38,7 +38,7 @@ let of_yojson =
                 | '0'..'9' | 'a'..'f' | 'A'..'F' -> ()
                 | _ -> raise Invalid_hex
               ) data;
-            Result.Ok (Hex.to_string @@ `Hex data)
+            Ok (Hex.to_string @@ `Hex data)
           with Invalid_hex ->
             err "not valid hex-encoded data"
         end


### PR DESCRIPTION
Instead, rely on it being open or available in `Pervasives`.