### PR TITLE
FreeBSD support

### DIFF
--- a/src/snippets/prelude.h
+++ b/src/snippets/prelude.h
@@ -10,7 +10,7 @@
 #include <windows.h>
 #else
 
-#if defined(__linux__) || (defined(__sun) && defined(__SVR4))
+#if defined(__linux__) || defined(__FreeBSD__) || (defined(__sun) && defined(__SVR4))
 #include <dlfcn.h>
 #endif
 #ifdef _AIX


### PR DESCRIPTION
There are two changes needed to get PKCS11 (and the example application) to work on FreeBSD:
- `include <dlfcn.h>`
- don't use the `RTLD_DEEPBIND` flag on FreeBSD (since it is not defined there, and ctypes will raise an assertion failure otherwise).

The second item is done at runtime, after investigating the output of `uname -s`.  Since `Pkcs11.load_driver` is called rarely, I guess spawning a new process which runs `uname -s` is ok.