### PR TITLE
Use separate integers package and ctypes >= 0.12.0

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -8,6 +8,7 @@ PKG cmdliner
 PKG ctypes.foreign
 PKG ctypes.stubs
 PKG hex
+PKG integers
 PKG key-parsers
 PKG oUnit
 PKG ppx_deriving.std

--- a/_tags
+++ b/_tags
@@ -2,6 +2,7 @@ true: bin_annot
 true: package(ctypes.foreign)
 true: package(ctypes.stubs)
 true: package(hex)
+true: package(integers)
 true: package(key-parsers)
 true: package(ppx_deriving.std)
 true: package(ppx_deriving_yojson)

--- a/opam
+++ b/opam
@@ -14,9 +14,10 @@ build-test: [
   [ "ocaml" "pkg/pkg.ml" "test" ]
 ]
 depends: [
-  "ctypes" { >= "0.11.0" }
+  "ctypes" { >= "0.12.0" }
   "ctypes-foreign" { >= "0.4.0" }
   "hex" { >= "1.0.0" }
+  "integers"
   "key-parsers" { >= "0.5.0" & != "0.6.0" }
   "ppx_deriving" { >= "4.0" }
   "ppx_deriving_yojson" { >= "3.0" }


### PR DESCRIPTION
This brings us closer to a ctypes-independent package, should we need it.