### PR TITLE
Remove Low_level and Intermediate_level

### DIFF
--- a/src_driver/p11_driver.ml
+++ b/src_driver/p11_driver.ml
@@ -109,18 +109,12 @@ sig
   val derive_key :
     Session_handle.t -> Mechanism.t -> Object_handle.t -> Template.t ->
     Object_handle.t
-
-  module Intermediate_level : Pkcs11.S
-  module Low_level : Pkcs11.RAW
-
 end
 
 module Make (X: Pkcs11.RAW) =
 struct
-
-  module Low_level = X
   module Intermediate_level = Pkcs11.Make(X)
-  include Intermediate_level
+  open Intermediate_level
 
   type 'a t = 'a
   let return x = x

--- a/src_driver/p11_driver.mli
+++ b/src_driver/p11_driver.mli
@@ -109,9 +109,6 @@ sig
   val derive_key :
     Session_handle.t -> Mechanism.t -> Object_handle.t -> Template.t ->
     Object_handle.t
-
-  module Intermediate_level : Pkcs11.S
-  module Low_level : Pkcs11.RAW
 end
 
 module Make (X: Pkcs11.RAW): S


### PR DESCRIPTION
These are unused and grow the signature a lot.