### PR TITLE
Use travis-opam 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - PACKAGE=pkcs11
     - DISTRO=debian-stable
     - DEPOPTS="ctypes ctypes-foreign"
+    - FORK_BRANCH=v1.1.0
   matrix:
     - OCAML_VERSION=4.02.3
     - OCAML_VERSION=4.03.0


### PR DESCRIPTION
By default, it will use the latest release on opam, which is 1.0.3 right
now. This release does not run tests for the depopts run.

Closes #65