### PR TITLE
Cleanup CK_ATTRIBUTE internals

### DIFF
--- a/src_driver/pkcs11_CK_ATTRIBUTE.ml
+++ b/src_driver/pkcs11_CK_ATTRIBUTE.ml
@@ -226,7 +226,6 @@ let repr (type a) : a P11_attribute_type.t -> a repr =
 
 let view t =
   let open P11_attribute_type in
-  let open Pkcs11_CK_ATTRIBUTE_TYPE in
   let ul = getf t _type in
   let Pack attribute_type = Pkcs11_CK_ATTRIBUTE_TYPE.view ul in
   let repr = repr attribute_type in

--- a/src_driver/pkcs11_CK_ATTRIBUTE.ml
+++ b/src_driver/pkcs11_CK_ATTRIBUTE.ml
@@ -163,6 +163,17 @@ let repr_view (type a) t : a repr -> a =
   | Repr_ulong -> unsafe_get_ulong t
   | Repr_key_gen_mechanism -> Pkcs11_key_gen_mechanism.view (unsafe_get_ulong t)
 
+let repr_make (type a) at (param:a) : a repr -> _ =
+  function
+  | Repr_object_class -> ulong at (Pkcs11_CK_OBJECT_CLASS.make param)
+  | Repr_bool -> boolean at param
+  | Repr_string -> string at param
+  | Repr_not_implemented -> let P11_attribute_type.NOT_IMPLEMENTED s = param in string at s
+  | Repr_key_type -> ulong at (Pkcs11_CK_KEY_TYPE.make param)
+  | Repr_bigint -> bigint at param
+  | Repr_ulong -> ulong at param
+  | Repr_key_gen_mechanism -> ulong at (Pkcs11_key_gen_mechanism.make param)
+
 let repr (type a) : a P11_attribute_type.t -> a repr =
   let open P11_attribute_type in
   function
@@ -232,63 +243,11 @@ let view t =
   let param = repr_view t repr in
   pack (attribute_type, param)
 
-let make (type s) (x:s u) =
-  let open P11_attribute_type in
-  match x with
-  | CKA_CLASS, cko -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CLASS (Pkcs11_CK_OBJECT_CLASS.make cko)
-  | CKA_TOKEN, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_TOKEN b
-  | CKA_PRIVATE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIVATE b
-  | CKA_LABEL, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_LABEL s
-  | CKA_VALUE, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VALUE s
-  | CKA_TRUSTED, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_TRUSTED b
-  | CKA_CHECK_VALUE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CHECK_VALUE s
-  | CKA_KEY_TYPE, ckk -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_TYPE (Pkcs11_CK_KEY_TYPE.make ckk)
-  | CKA_SUBJECT, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SUBJECT s
-  | CKA_ID, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ID s
-  | CKA_SENSITIVE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SENSITIVE b
-  | CKA_ENCRYPT,   b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ENCRYPT   b
-  | CKA_DECRYPT,   b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_DECRYPT   b
-  | CKA_WRAP, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_WRAP b
-  | CKA_UNWRAP, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_UNWRAP b
-  | CKA_SIGN, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SIGN b
-  | CKA_SIGN_RECOVER, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SIGN_RECOVER b
-  | CKA_VERIFY, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VERIFY b
-  | CKA_VERIFY_RECOVER, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VERIFY_RECOVER b
-  | CKA_DERIVE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_DERIVE b
-  | CKA_START_DATE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_START_DATE s
-  | CKA_END_DATE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_END_DATE s
-  | CKA_MODULUS, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS n
-  | CKA_MODULUS_BITS,     ul -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS_BITS     ul
-  | CKA_PUBLIC_EXPONENT, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PUBLIC_EXPONENT n
-  | CKA_PRIVATE_EXPONENT, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIVATE_EXPONENT n
-  | CKA_PRIME_1, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIME_1 n
-  | CKA_PRIME_2, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIME_2 n
-  | CKA_EXPONENT_1, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_EXPONENT_1 n
-  | CKA_EXPONENT_2, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_EXPONENT_2 n
-  | CKA_COEFFICIENT, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_COEFFICIENT n
-  | CKA_PRIME, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIME n
-  | CKA_SUBPRIME, n -> bigint Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SUBPRIME n
-  | CKA_PRIME_BITS, ul -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_PRIME_BITS ul
-  | CKA_SUBPRIME_BITS, ul -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_SUBPRIME_BITS ul
-  | CKA_VALUE_LEN, ul -> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_VALUE_LEN ul
-  | CKA_EXTRACTABLE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_EXTRACTABLE b
-  | CKA_LOCAL,  b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_LOCAL  b
-  | CKA_NEVER_EXTRACTABLE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_NEVER_EXTRACTABLE b
-  | CKA_ALWAYS_SENSITIVE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ALWAYS_SENSITIVE b
-  | CKA_KEY_GEN_MECHANISM, m ->
-      Pkcs11_key_gen_mechanism.make m
-      |> ulong Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_GEN_MECHANISM
-  | CKA_MODIFIABLE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODIFIABLE b
-  (* | CKA_ECDSA_PARAMS, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ECDSA_PARAMS s *)
-  | CKA_EC_PARAMS, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_EC_PARAMS s
-  | CKA_EC_POINT, s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_EC_POINT s
-  | CKA_ALWAYS_AUTHENTICATE, b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ALWAYS_AUTHENTICATE b
-  | CKA_WRAP_WITH_TRUSTED,   b -> boolean Pkcs11_CK_ATTRIBUTE_TYPE._CKA_WRAP_WITH_TRUSTED   b
-  | CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_WRAP_TEMPLATE s
-  | CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_UNWRAP_TEMPLATE s
-  | CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED s -> string Pkcs11_CK_ATTRIBUTE_TYPE._CKA_ALLOWED_MECHANISMS s
-  | CKA_CS_UNKNOWN ul, NOT_IMPLEMENTED s ->
-      string ul s
+let make (type s) ((at, param):s u) =
+  repr_make
+    (Pkcs11_CK_ATTRIBUTE_TYPE.make at)
+    param
+    (repr at)
 
 let make_pack (P11_attribute.Pack x) = make x
 

--- a/src_driver/pkcs11_CK_ATTRIBUTE.mli
+++ b/src_driver/pkcs11_CK_ATTRIBUTE.mli
@@ -6,7 +6,8 @@ type 'a u = 'a P11_attribute_type.t * 'a
 val boolean : Pkcs11_CK_ATTRIBUTE_TYPE.t -> bool -> t
 val byte : Pkcs11_CK_ATTRIBUTE_TYPE.t -> int -> t
 val ulong : Pkcs11_CK_ATTRIBUTE_TYPE.t -> P11_ulong.t -> t
-val string  : Pkcs11_CK_ATTRIBUTE_TYPE.t -> string ->t
+val string : Pkcs11_CK_ATTRIBUTE_TYPE.t -> string -> t
+val bigint : Pkcs11_CK_ATTRIBUTE_TYPE.t -> P11_bigint.t -> t
 
 val create : Pkcs11_CK_ATTRIBUTE_TYPE.t -> t
 val allocate : t -> unit

--- a/test/test_ck_attribute.ml
+++ b/test/test_ck_attribute.ml
@@ -1,0 +1,103 @@
+open OUnit2
+
+let test_view =
+  let test low expected ctxt =
+    let got = Pkcs11_CK_ATTRIBUTE.view low in
+    assert_equal
+      ~ctxt
+      ~cmp:[%eq: P11_attribute.pack]
+      ~printer:[%show: P11_attribute.pack]
+      expected
+      got
+  in
+  let object_class = P11_object_class.CKO_SECRET_KEY in
+  let key_type = P11_key_type.CKK_AES in
+  let bool = true in
+  let string = "string" in
+  let bigint = P11_bigint.zero in
+  let ulong = Unsigned.ULong.zero in
+  let key_gen_mechanism = P11_key_gen_mechanism.CK_UNAVAILABLE_INFORMATION in
+  let unknown_ckm = Unsigned.ULong.of_int 0x5555 in
+  "view" >:::
+  [ "object_class" >:: test
+      (Pkcs11_CK_ATTRIBUTE.ulong
+         Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CLASS
+         (Pkcs11_CK_OBJECT_CLASS.make object_class)
+      )
+      (P11_attribute.Pack
+         (P11_attribute_type.CKA_CLASS, object_class)
+      )
+  ; "bool" >:: test
+      (Pkcs11_CK_ATTRIBUTE.boolean
+         Pkcs11_CK_ATTRIBUTE_TYPE._CKA_TOKEN
+         bool
+      )
+      (P11_attribute.Pack
+         (P11_attribute_type.CKA_TOKEN, bool)
+      )
+  ; "string" >:: test
+      (Pkcs11_CK_ATTRIBUTE.string
+         Pkcs11_CK_ATTRIBUTE_TYPE._CKA_LABEL
+         string
+      )
+      (P11_attribute.Pack
+         (P11_attribute_type.CKA_LABEL, string)
+      )
+  ; "not implemented" >:: test
+      (Pkcs11_CK_ATTRIBUTE.string
+         Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CHECK_VALUE
+         string
+      )
+      (P11_attribute.Pack
+         ( P11_attribute_type.CKA_CHECK_VALUE
+         , P11_attribute_type.NOT_IMPLEMENTED string
+         )
+      )
+  ; "key_type" >:: test
+      (Pkcs11_CK_ATTRIBUTE.ulong
+         Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_TYPE
+         (Pkcs11_CK_KEY_TYPE.make key_type)
+      )
+      (P11_attribute.Pack
+         (P11_attribute_type.CKA_KEY_TYPE, key_type)
+      )
+  ; "bigint" >:: test
+      (Pkcs11_CK_ATTRIBUTE.bigint
+         Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS
+         bigint
+      )
+      (P11_attribute.Pack
+         (P11_attribute_type.CKA_MODULUS, bigint)
+      )
+  ; "ulong" >:: test
+      (Pkcs11_CK_ATTRIBUTE.ulong
+         Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS_BITS
+         ulong
+      )
+      (P11_attribute.Pack
+         (P11_attribute_type.CKA_MODULUS_BITS, ulong)
+      )
+  ; "key_gen_mechanism" >:: test
+      (Pkcs11_CK_ATTRIBUTE.ulong
+         Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_GEN_MECHANISM
+         (Pkcs11_key_gen_mechanism.make key_gen_mechanism)
+      )
+      (P11_attribute.Pack
+         (P11_attribute_type.CKA_KEY_GEN_MECHANISM, key_gen_mechanism)
+      )
+  ; "unknown" >:: test
+      (Pkcs11_CK_ATTRIBUTE.string
+         unknown_ckm
+         string
+      )
+      (P11_attribute.Pack
+         ( P11_attribute_type.CKA_CS_UNKNOWN unknown_ckm
+         , P11_attribute_type.NOT_IMPLEMENTED string
+         )
+      )
+  ]
+
+let suite =
+  "CK_ATTRIBUTE" >:::
+  [ test_view
+  ]

--- a/test/test_ck_attribute.ml
+++ b/test/test_ck_attribute.ml
@@ -1,5 +1,16 @@
 open OUnit2
 
+module F = struct
+  let object_class = P11_object_class.CKO_SECRET_KEY
+  let key_type = P11_key_type.CKK_AES
+  let bool = true
+  let string = "string"
+  let bigint = P11_bigint.of_int 65537
+  let ulong = Unsigned.ULong.zero
+  let key_gen_mechanism = P11_key_gen_mechanism.CK_UNAVAILABLE_INFORMATION
+  let unknown_ckm = Unsigned.ULong.of_int 0x5555
+end
+
 let test_view =
   let test low expected ctxt =
     let got = Pkcs11_CK_ATTRIBUTE.view low in
@@ -10,94 +21,138 @@ let test_view =
       expected
       got
   in
-  let object_class = P11_object_class.CKO_SECRET_KEY in
-  let key_type = P11_key_type.CKK_AES in
-  let bool = true in
-  let string = "string" in
-  let bigint = P11_bigint.zero in
-  let ulong = Unsigned.ULong.zero in
-  let key_gen_mechanism = P11_key_gen_mechanism.CK_UNAVAILABLE_INFORMATION in
-  let unknown_ckm = Unsigned.ULong.of_int 0x5555 in
   "view" >:::
   [ "object_class" >:: test
       (Pkcs11_CK_ATTRIBUTE.ulong
          Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CLASS
-         (Pkcs11_CK_OBJECT_CLASS.make object_class)
+         (Pkcs11_CK_OBJECT_CLASS.make F.object_class)
       )
       (P11_attribute.Pack
-         (P11_attribute_type.CKA_CLASS, object_class)
+         (P11_attribute_type.CKA_CLASS, F.object_class)
       )
   ; "bool" >:: test
       (Pkcs11_CK_ATTRIBUTE.boolean
          Pkcs11_CK_ATTRIBUTE_TYPE._CKA_TOKEN
-         bool
+         F.bool
       )
       (P11_attribute.Pack
-         (P11_attribute_type.CKA_TOKEN, bool)
+         (P11_attribute_type.CKA_TOKEN, F.bool)
       )
   ; "string" >:: test
       (Pkcs11_CK_ATTRIBUTE.string
          Pkcs11_CK_ATTRIBUTE_TYPE._CKA_LABEL
-         string
+         F.string
       )
       (P11_attribute.Pack
-         (P11_attribute_type.CKA_LABEL, string)
+         (P11_attribute_type.CKA_LABEL, F.string)
       )
   ; "not implemented" >:: test
       (Pkcs11_CK_ATTRIBUTE.string
          Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CHECK_VALUE
-         string
+         F.string
       )
       (P11_attribute.Pack
          ( P11_attribute_type.CKA_CHECK_VALUE
-         , P11_attribute_type.NOT_IMPLEMENTED string
+         , P11_attribute_type.NOT_IMPLEMENTED F.string
          )
       )
   ; "key_type" >:: test
       (Pkcs11_CK_ATTRIBUTE.ulong
          Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_TYPE
-         (Pkcs11_CK_KEY_TYPE.make key_type)
+         (Pkcs11_CK_KEY_TYPE.make F.key_type)
       )
       (P11_attribute.Pack
-         (P11_attribute_type.CKA_KEY_TYPE, key_type)
+         (P11_attribute_type.CKA_KEY_TYPE, F.key_type)
       )
   ; "bigint" >:: test
       (Pkcs11_CK_ATTRIBUTE.bigint
          Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS
-         bigint
+         F.bigint
       )
       (P11_attribute.Pack
-         (P11_attribute_type.CKA_MODULUS, bigint)
+         (P11_attribute_type.CKA_MODULUS, F.bigint)
       )
   ; "ulong" >:: test
       (Pkcs11_CK_ATTRIBUTE.ulong
          Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS_BITS
-         ulong
+         F.ulong
       )
       (P11_attribute.Pack
-         (P11_attribute_type.CKA_MODULUS_BITS, ulong)
+         (P11_attribute_type.CKA_MODULUS_BITS, F.ulong)
       )
   ; "key_gen_mechanism" >:: test
       (Pkcs11_CK_ATTRIBUTE.ulong
          Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_GEN_MECHANISM
-         (Pkcs11_key_gen_mechanism.make key_gen_mechanism)
+         (Pkcs11_key_gen_mechanism.make F.key_gen_mechanism)
       )
       (P11_attribute.Pack
-         (P11_attribute_type.CKA_KEY_GEN_MECHANISM, key_gen_mechanism)
+         (P11_attribute_type.CKA_KEY_GEN_MECHANISM, F.key_gen_mechanism)
       )
   ; "unknown" >:: test
       (Pkcs11_CK_ATTRIBUTE.string
-         unknown_ckm
-         string
+         F.unknown_ckm
+         F.string
       )
       (P11_attribute.Pack
-         ( P11_attribute_type.CKA_CS_UNKNOWN unknown_ckm
-         , P11_attribute_type.NOT_IMPLEMENTED string
+         ( P11_attribute_type.CKA_CS_UNKNOWN F.unknown_ckm
+         , P11_attribute_type.NOT_IMPLEMENTED F.string
          )
       )
+  ]
+
+let test_make =
+  let test high expected ctxt =
+    let low = Pkcs11_CK_ATTRIBUTE.make high in
+    let got_tag = Pkcs11_CK_ATTRIBUTE.get_type low in
+    let got_len = Pkcs11_CK_ATTRIBUTE.get_length low in
+    let is_null = Pkcs11_CK_ATTRIBUTE.pvalue_is_null_ptr low in
+    assert_bool
+      "Pointer should not be NULL"
+      (not is_null);
+    let got = (got_tag, got_len) in
+    assert_equal
+      ~ctxt
+      ~cmp:[%eq: P11_ulong.t * int]
+      ~printer:[%show: P11_ulong.t * int]
+      expected
+      got
+  in
+  "make" >:::
+  [ "object_class" >:: test
+      (P11.Attribute_type.CKA_CLASS, F.object_class)
+      (Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CLASS, Ctypes.sizeof Pkcs11_CK_OBJECT_CLASS.typ)
+  ; "bool" >:: test
+      (P11.Attribute_type.CKA_TOKEN, F.bool)
+      (Pkcs11_CK_ATTRIBUTE_TYPE._CKA_TOKEN, Ctypes.sizeof Pkcs11_CK_BBOOL.typ)
+  ; "string" >:: test
+      (P11.Attribute_type.CKA_LABEL, F.string)
+      (Pkcs11_CK_ATTRIBUTE_TYPE._CKA_LABEL, String.length F.string)
+  ; "not implemented" >:: test
+      ( P11_attribute_type.CKA_CHECK_VALUE
+      , P11_attribute_type.NOT_IMPLEMENTED F.string
+      )
+      (Pkcs11_CK_ATTRIBUTE_TYPE._CKA_CHECK_VALUE, String.length F.string)
+  ; "key_type" >:: test
+      (P11_attribute_type.CKA_KEY_TYPE, F.key_type)
+      (Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_TYPE, Ctypes.sizeof Ctypes.ulong)
+  ; "bigint" >:: test
+      (P11_attribute_type.CKA_MODULUS, F.bigint)
+      (Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS, 3)
+  ; "ulong" >:: test
+      (P11_attribute_type.CKA_MODULUS_BITS, F.ulong)
+      (Pkcs11_CK_ATTRIBUTE_TYPE._CKA_MODULUS_BITS, Ctypes.sizeof Ctypes.ulong)
+  ; "key_gen_mechanism" >:: test
+      (P11_attribute_type.CKA_KEY_GEN_MECHANISM, F.key_gen_mechanism)
+      (Pkcs11_CK_ATTRIBUTE_TYPE._CKA_KEY_GEN_MECHANISM, Ctypes.sizeof Ctypes.ulong)
+  ; "unknown" >:: test
+      ( P11_attribute_type.CKA_CS_UNKNOWN F.unknown_ckm
+      , P11_attribute_type.NOT_IMPLEMENTED F.string
+      )
+      (F.unknown_ckm, String.length F.string)
   ]
 
 let suite =
   "CK_ATTRIBUTE" >:::
   [ test_view
+  ; test_make
   ]

--- a/test/test_driver.ml
+++ b/test/test_driver.ml
@@ -10,6 +10,7 @@ let suite =
       ; Test_ck_mechanism_type.suite
       ; Test_ck_mechanism.suite
       ; Test_ck_aes_ctr_params.suite
+      ; Test_ck_attribute.suite
       ]
     ]
 


### PR DESCRIPTION
This is similar to #75 but for `CK_ATTRIBUTE`. The goal is to simplify adding new variants (especially of known types).

- extract a `repr` private type
- use it in `make` and `view`
- test these functions