### PR TITLE
Hex encode AES-CTR and AES-GCM parameters

### DIFF
--- a/src/p11_aes_ctr_params.ml
+++ b/src/p11_aes_ctr_params.ml
@@ -1,6 +1,6 @@
 type t =
   { bits: P11_ulong.t
-  ; block: string
+  ; block: P11_hex_data.t
   }
 [@@deriving eq,make,ord,show,yojson]
 

--- a/src/p11_gcm_params.ml
+++ b/src/p11_gcm_params.ml
@@ -1,6 +1,6 @@
 type t =
-  { iv: string
-  ; aad: string
+  { iv: P11_hex_data.t
+  ; aad: P11_hex_data.t
   ; tag_bits: P11_ulong.t
   }
 [@@deriving eq,ord,make,show,yojson]

--- a/test/test_p11_aes_ctr_params.ml
+++ b/test/test_p11_aes_ctr_params.ml
@@ -50,7 +50,7 @@ let test_to_yojson =
       )
       ( `Assoc
           [ ("bits", `String "64")
-          ; ("block", `String "AAAABBBBCCCCDDDD")
+          ; ("block", `String "0x41414141424242424343434344444444")
           ]
       )
   ]
@@ -69,7 +69,7 @@ let test_of_yojson =
   [ "normal" >:: test
       (`Assoc
          [ ("bits", `String "64")
-         ; ("block", `String "AAAABBBBCCCCDDDD")
+         ; ("block", `String "0x41414141424242424343434344444444")
          ]
       )
       ( Ok

--- a/test/test_p11_gcm_params.ml
+++ b/test/test_p11_gcm_params.ml
@@ -41,8 +41,8 @@ let test_of_yojson =
     let tag_bits = Unsigned.ULong.of_int 16 in
     let json =
       `Assoc
-        [ "iv", `String iv
-        ; "aad", `String aad
+        [ "iv", `String "0x6976"
+        ; "aad", `String "0x616164"
         ; "tag_bits", `String "16"
         ]
     in
@@ -62,8 +62,8 @@ let test_to_yojson =
     let tag_bits = Unsigned.ULong.of_int 16 in
     let expected =
       `Assoc
-        [ "iv", `String iv
-        ; "aad", `String aad
+        [ "iv", `String "0x6976"
+        ; "aad", `String "0x616164"
         ; "tag_bits", `String "16"
         ]
     in


### PR DESCRIPTION
Since they contain binary data, they can generate invalid JSON.