### PR TITLE
Drop compatibility with 4.02.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - DEPOPTS="ctypes ctypes-foreign"
     - FORK_BRANCH=v1.1.0
   matrix:
-    - OCAML_VERSION=4.02.3
     - OCAML_VERSION=4.03.0
     - OCAML_VERSION=4.04.0
     - OCAML_VERSION=4.05.0

--- a/opam
+++ b/opam
@@ -42,4 +42,4 @@ conflicts: [
   "ctypes" { < "0.12.0" }
 ]
 tags: ["org:cryptosense"]
-available: [ocaml-version >= "4.02.0" & os != "darwin"]
+available: [ocaml-version >= "4.03.0" & os != "darwin"]


### PR DESCRIPTION
The code generated by `ppx_deriving` unfortunately triggers a bug in the
OCaml compiler, which makes the compilation really slow.

In case a 4.02.3 build is required, most changes should be related to
the `result` type.

See https://caml.inria.fr/mantis/view.php?id=6646