### PR TITLE
Support CKM_AES_KEY_WRAP mechanism

### DIFF
--- a/src/p11_aes_key_wrap_params.ml
+++ b/src/p11_aes_key_wrap_params.ml
@@ -1,0 +1,8 @@
+type t = P11_hex_data.t option
+[@@deriving eq,ord,show,yojson]
+
+let default = None
+
+let explicit iv = Some iv
+
+let explicit_iv x = x

--- a/src/p11_aes_key_wrap_params.mli
+++ b/src/p11_aes_key_wrap_params.mli
@@ -1,0 +1,16 @@
+(**
+   Parameters for [CKM_AES_KEY_WRAP].
+   Note that the name of this module is not in PKCS11,
+   where it is just described as a nullable pointer.
+*)
+type t
+[@@deriving eq,ord,show,yojson]
+
+(** Use the default IV as specified in the AES-KEYWRAP specification. *)
+val default: t
+
+(** Use this IV. It should be exactly 8 bytes long for PKCS11 compliant DLLs. *)
+val explicit: string -> t
+
+(** Return the explicit IV, or None if the default value was used. *)
+val explicit_iv: t -> string option

--- a/src/p11_mechanism.ml
+++ b/src/p11_mechanism.ml
@@ -71,6 +71,7 @@ type t =
   | CKM_SHA384_HMAC
   | CKM_SHA512_HMAC
   | CKM_GENERIC_SECRET_KEY_GEN
+  | CKM_AES_KEY_WRAP of P11_aes_key_wrap_params.t
   | CKM_CS_UNKNOWN of P11_ulong.t
 [@@deriving eq,ord,show]
 
@@ -211,6 +212,8 @@ let to_json =
     | CKM_SHA384_HMAC -> simple "CKM_SHA384_HMAC"
     | CKM_SHA512_HMAC -> simple "CKM_SHA512_HMAC"
     | CKM_GENERIC_SECRET_KEY_GEN -> simple "CKM_GENERIC_SECRET_KEY_GEN"
+    | CKM_AES_KEY_WRAP p ->
+      param "CKM_AES_KEY_WRAP" p P11_aes_key_wrap_params.to_yojson
     | CKM_CS_UNKNOWN p ->
         param "CKM_NOT_IMPLEMENTED" p P11_ulong.to_yojson
 
@@ -315,6 +318,9 @@ let of_yojson json =
       | "CKM_SHA384_HMAC" -> simple CKM_SHA384_HMAC
       | "CKM_SHA512_HMAC" -> simple CKM_SHA512_HMAC
       | "CKM_GENERIC_SECRET_KEY_GEN" -> simple CKM_GENERIC_SECRET_KEY_GEN
+      | "CKM_AES_KEY_WRAP" ->
+        P11_aes_key_wrap_params.of_yojson param >>= fun r ->
+        Ok (CKM_AES_KEY_WRAP r)
       | _ ->
         P11_ulong.of_yojson param >>= fun params ->
         Ok (CKM_CS_UNKNOWN params)
@@ -404,6 +410,7 @@ let mechanism_type m =
     | CKM_SHA384_HMAC -> T.CKM_SHA384_HMAC
     | CKM_SHA512_HMAC -> T.CKM_SHA512_HMAC
     | CKM_GENERIC_SECRET_KEY_GEN -> T.CKM_GENERIC_SECRET_KEY_GEN
+    | CKM_AES_KEY_WRAP _ -> T.CKM_AES_KEY_WRAP
     | CKM_CS_UNKNOWN mechanism_type ->
       T.CKM_CS_UNKNOWN mechanism_type
 
@@ -753,6 +760,7 @@ let key_type = function
   | CKM_AES_CBC_ENCRYPT_DATA _
   | CKM_AES_CTR _
   | CKM_AES_GCM _
+  | CKM_AES_KEY_WRAP _
     -> Some P11_key_type.CKK_AES
   | CKM_DES_KEY_GEN
   | CKM_DES_ECB

--- a/src/p11_mechanism.mli
+++ b/src/p11_mechanism.mli
@@ -71,6 +71,7 @@ type t =
   | CKM_SHA384_HMAC
   | CKM_SHA512_HMAC
   | CKM_GENERIC_SECRET_KEY_GEN
+  | CKM_AES_KEY_WRAP of P11_aes_key_wrap_params.t
   | CKM_CS_UNKNOWN of P11_ulong.t
 [@@deriving eq,ord,show,yojson]
 

--- a/test/test_p11_aes_key_wrap.ml
+++ b/test/test_p11_aes_key_wrap.ml
@@ -1,0 +1,64 @@
+open OUnit2
+
+
+type yojson =
+  [ `Null
+  | `Bool of bool
+  | `Int of int
+  | `Float of float
+  | `String of string
+  | `Intlit of string
+  | `List of yojson list
+  | `Tuple of yojson list
+  | `Assoc of (string * yojson) list
+  | `Variant of (string * yojson option)
+  ]
+[@@deriving eq,show]
+
+
+let test_to_yojson =
+  let test params expected ctxt =
+    let got = P11_aes_key_wrap_params.to_yojson params in
+    assert_equal
+      ~ctxt
+      ~cmp:[%eq: yojson]
+      ~printer:[%show: yojson]
+      expected
+      got
+  in
+  "to_yojson" >:::
+  [ "default" >:: test
+    P11_aes_key_wrap_params.default
+    `Null
+  ; "explicit" >:: test
+    (P11_aes_key_wrap_params.explicit "AAAABBBBCCCCDDDD")
+    (`String "0x41414141424242424343434344444444")
+  ]
+
+
+let test_explicit_iv =
+  let test params expected ctxt =
+    let got = P11_aes_key_wrap_params.explicit_iv params in
+    assert_equal
+      ~ctxt
+      ~cmp:[%eq: string option]
+      ~printer:[%show: string option]
+      expected
+      got
+  in
+  let iv = "12345678" in
+  "explicit_iv" >:::
+  [ "Default" >:: test
+      P11_aes_key_wrap_params.default
+      None
+  ; "Explicit" >:: test
+      (P11_aes_key_wrap_params.explicit iv)
+      (Some iv)
+  ]
+
+
+let suite =
+  "P11_aes_key_wrap" >:::
+  [ test_to_yojson
+  ; test_explicit_iv
+  ]

--- a/test/test_suite.ml
+++ b/test/test_suite.ml
@@ -9,6 +9,7 @@ let suite =
   ; Test_p11_aes_ctr_params.suite
   ; Test_p11_gcm_params.suite
   ; Test_p11_mechanism.suite
+  ; Test_p11_aes_key_wrap.suite
   ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
Already enjoying `CKM_AES_KEY_WRAP`-the-mechanism-type? You'll love `CKM_AES_KEY_WRAP`-the-mechanism.

It's a bit of a special case in that its parameter is a string, but `NULL` can be passed as well. I created an abstract type for that, but it's pretty obvious that it's backed by a `string option`. On the driver side, this reuses pieces of string-handling code, so there's no corresponding `Pkcs11_CK_AES_KEY_WRAP_params` module (this name does not exist in PKCS11).