### PR TITLE
Fix P11_aes_key_wrap_params installation

### DIFF
--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -6,6 +6,7 @@ let api =
   [ "P11"
   ; "P11_aes_cbc_encrypt_data_params"
   ; "P11_aes_ctr_params"
+  ; "P11_aes_key_wrap_params"
   ; "P11_attribute"
   ; "P11_attribute_type"
   ; "P11_attribute_types"

--- a/src/p11.ml
+++ b/src/p11.ml
@@ -35,3 +35,4 @@ module Template = P11_template
 module EC_KDF = P11_ec_kdf
 module AES_CTR_params = P11_aes_ctr_params
 module GCM_params = P11_gcm_params
+module AES_key_wrap_params = P11_aes_key_wrap_params

--- a/src/p11.mli
+++ b/src/p11.mli
@@ -36,3 +36,4 @@ module Template = P11_template
 module EC_KDF = P11_ec_kdf
 module AES_CTR_params = P11_aes_ctr_params
 module GCM_params = P11_gcm_params
+module AES_key_wrap_params = P11_aes_key_wrap_params

--- a/src/pkcs11.mllib
+++ b/src/pkcs11.mllib
@@ -1,6 +1,7 @@
 P11
 P11_aes_cbc_encrypt_data_params
 P11_aes_ctr_params
+P11_aes_key_wrap_params
 P11_attribute
 P11_attribute_type
 P11_attribute_types


### PR DESCRIPTION
Without this, `utop -require pkcs11` (or any other use) fails.