### PR TITLE
P11_driver: add an API not based on modules

### DIFF
--- a/src_driver/p11_driver.ml
+++ b/src_driver/p11_driver.ml
@@ -637,6 +637,62 @@ struct
 
 end
 
+type t = (module S)
+
+let initialize (module S : S) = S.initialize ()
+let finalize (module S : S) = S.finalize ()
+let get_info (module S : S) = S.get_info ()
+let get_slot (module S : S) = S.get_slot
+let get_slot_list (module S : S) = S.get_slot_list
+let get_slot_info (module S : S) = S.get_slot_info
+let get_token_info (module S : S) = S.get_token_info
+let get_mechanism_list (module S : S) = S.get_mechanism_list
+let get_mechanism_info (module S : S) = S.get_mechanism_info
+let init_token (module S : S) = S.init_token
+let init_PIN (module S : S) = S.init_PIN
+let set_PIN (module S : S) = S.set_PIN
+let open_session (module S : S) = S.open_session
+let close_session (module S : S) = S.close_session
+let close_all_sessions (module S : S) = S.close_all_sessions
+let get_session_info (module S : S) = S.get_session_info
+let login (module S : S) = S.login
+let logout (module S : S) = S.logout
+let create_object (module S : S) = S.create_object
+let copy_object (module S : S) = S.copy_object
+let destroy_object (module S : S) = S.destroy_object
+let get_attribute_value (module S : S) = S.get_attribute_value
+let get_attribute_value' (module S : S) = S.get_attribute_value'
+let get_attribute_value_optimized (module S : S) = S.get_attribute_value_optimized
+let set_attribute_value (module S : S) = S.set_attribute_value
+let find_objects (module S : S) = S.find_objects
+let encrypt (module S : S) = S.encrypt
+let multipart_encrypt_init (module S : S) = S.multipart_encrypt_init
+let multipart_encrypt_chunck (module S : S) = S.multipart_encrypt_chunck
+let multipart_encrypt_final (module S : S) = S.multipart_encrypt_final
+let multipart_encrypt (module S : S) = S.multipart_encrypt
+let decrypt (module S : S) = S.decrypt
+let multipart_decrypt_init (module S : S) = S.multipart_decrypt_init
+let multipart_decrypt_chunck (module S : S) = S.multipart_decrypt_chunck
+let multipart_decrypt_final (module S : S) = S.multipart_decrypt_final
+let multipart_decrypt (module S : S) = S.multipart_decrypt
+let sign (module S : S) = S.sign
+let sign_recover (module S : S) = S.sign_recover
+let multipart_sign_init (module S : S) = S.multipart_sign_init
+let multipart_sign_chunck (module S : S) = S.multipart_sign_chunck
+let multipart_sign_final (module S : S) = S.multipart_sign_final
+let multipart_sign (module S : S) = S.multipart_sign
+let verify (module S : S) = S.verify
+let verify_recover (module S : S) = S.verify_recover
+let multipart_verify_init (module S : S) = S.multipart_verify_init
+let multipart_verify_chunck (module S : S) = S.multipart_verify_chunck
+let multipart_verify_final (module S : S) = S.multipart_verify_final
+let multipart_verify (module S : S) = S.multipart_verify
+let generate_key (module S : S) = S.generate_key
+let generate_key_pair (module S : S) = S.generate_key_pair
+let wrap_key (module S : S) = S.wrap_key
+let unwrap_key (module S : S) = S.unwrap_key
+let derive_key (module S : S) = S.derive_key
+
 let load_driver ?log_calls ?on_unknown ~dll ~use_get_function_list =
   let module Implem =
     (val (Pkcs11.load_driver ?log_calls ?on_unknown ~dll ~use_get_function_list) : Pkcs11.RAW)

--- a/src_driver/p11_driver.mli
+++ b/src_driver/p11_driver.mli
@@ -111,6 +111,62 @@ sig
     Object_handle.t
 end
 
+type t = (module S)
+
+val initialize : t -> unit
+val finalize : t -> unit
+val get_info : t -> Info.t
+val get_slot: t -> Slot.t -> (Slot_id.t, string) result
+val get_slot_list : t -> bool -> Slot_id.t list
+val get_slot_info : t -> slot: Slot_id.t -> Slot_info.t
+val get_token_info : t -> slot: Slot_id.t -> Token_info.t
+val get_mechanism_list : t -> slot: Slot_id.t -> Mechanism_type.t list
+val get_mechanism_info : t -> slot: Slot_id.t -> Mechanism_type.t -> Mechanism_info.t
+val init_token : t -> slot: Slot_id.t -> pin: string -> label: string -> unit
+val init_PIN : t -> Session_handle.t -> pin: string -> unit
+val set_PIN : t -> Session_handle.t -> oldpin: string -> newpin: string -> unit
+val open_session : t -> slot: Slot_id.t -> flags: Flags.t -> Session_handle.t
+val close_session : t -> Session_handle.t -> unit
+val close_all_sessions : t -> slot: Slot_id.t -> unit
+val get_session_info : t -> Session_handle.t -> Session_info.t
+val login : t -> Session_handle.t -> User_type.t -> string -> unit
+val logout : t -> Session_handle.t -> unit
+val create_object : t -> Session_handle.t -> Template.t -> Object_handle.t
+val copy_object : t -> Session_handle.t -> Object_handle.t -> Template.t -> Object_handle.t
+val destroy_object : t -> Session_handle.t -> Object_handle.t -> unit
+val get_attribute_value : t -> Session_handle.t -> Object_handle.t -> Attribute_types.t -> Template.t
+val get_attribute_value' : t -> Session_handle.t -> Object_handle.t -> Attribute_types.t -> Template.t
+val get_attribute_value_optimized : t -> Attribute_types.t -> [`Optimized of Session_handle.t -> Object_handle.t -> Template.t]
+val set_attribute_value : t -> Session_handle.t -> Object_handle.t -> Template.t -> unit
+val find_objects : t -> ?max_size:int -> Session_handle.t -> Template.t -> Object_handle.t list
+val encrypt : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t -> Data.t
+val multipart_encrypt_init : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> unit
+val multipart_encrypt_chunck : t -> Session_handle.t -> Data.t -> Data.t
+val multipart_encrypt_final : t -> Session_handle.t -> Data.t
+val multipart_encrypt : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t list -> Data.t
+val decrypt : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t -> Data.t
+val multipart_decrypt_init : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> unit
+val multipart_decrypt_chunck : t -> Session_handle.t -> Data.t -> Data.t
+val multipart_decrypt_final : t -> Session_handle.t -> Data.t
+val multipart_decrypt : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t list -> Data.t
+val sign : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t -> Data.t
+val sign_recover : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t -> Data.t
+val multipart_sign_init : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> unit
+val multipart_sign_chunck : t -> Session_handle.t -> Data.t -> unit
+val multipart_sign_final : t -> Session_handle.t -> Data.t
+val multipart_sign : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t list -> Data.t
+val verify : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> data: Data.t -> signature: Data.t -> unit
+val verify_recover : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> signature: Data.t -> Data.t
+val multipart_verify_init : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> unit
+val multipart_verify_chunck : t -> Session_handle.t -> Data.t -> unit
+val multipart_verify_final : t -> Session_handle.t -> Data.t -> unit
+val multipart_verify : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t list -> Data.t -> unit
+val generate_key : t -> Session_handle.t -> Mechanism.t -> Template.t -> Object_handle.t
+val generate_key_pair : t -> Session_handle.t -> Mechanism.t -> Template.t -> Template.t -> (Object_handle.t * Object_handle.t)
+val wrap_key : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Object_handle.t -> Data.t
+val unwrap_key : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Data.t -> Template.t -> Object_handle.t
+val derive_key : t -> Session_handle.t -> Mechanism.t -> Object_handle.t -> Template.t -> Object_handle.t
+
 module Make (X: Pkcs11.RAW): S
 
 (** May raise [Pkcs11.Cannot_load_module].  [on_unknown] will be called with a warning
@@ -120,4 +176,4 @@ val load_driver:
   ?on_unknown:(string -> unit) ->
   dll: string ->
   use_get_function_list: [ `Auto | `False | `True ] ->
-  (module S)
+  t


### PR DESCRIPTION
First class modules are handy, but a bit verbose, and the type inference is limited.

This new API complements the former one for cases when packed modules are passed around.