### PR TITLE
load_driver: make dll argument non-named

### DIFF
--- a/src_driver/p11_driver.ml
+++ b/src_driver/p11_driver.ml
@@ -706,8 +706,8 @@ let unwrap_key (module S : S) = S.unwrap_key
 let derive_key (module S : S) = S.derive_key
 let digest (module S : S) = S.digest
 
-let load_driver ?log_calls ?on_unknown ~dll ~use_get_function_list =
+let load_driver ?log_calls ?on_unknown ~use_get_function_list dll =
   let module Implem =
-    (val (Pkcs11.load_driver ?log_calls ?on_unknown ~dll ~use_get_function_list) : Pkcs11.RAW)
+    (val (Pkcs11.load_driver ?log_calls ?on_unknown ~use_get_function_list dll) : Pkcs11.RAW)
   in
   (module (Make (Implem)): S)

--- a/src_driver/p11_driver.mli
+++ b/src_driver/p11_driver.mli
@@ -177,6 +177,6 @@ module Make (X: Pkcs11.RAW): S
 val load_driver:
   ?log_calls:(string * Format.formatter) ->
   ?on_unknown:(string -> unit) ->
-  dll: string ->
   use_get_function_list: [ `Auto | `False | `True ] ->
+  string ->
   t

--- a/src_driver/pkcs11.ml
+++ b/src_driver/pkcs11.ml
@@ -1360,7 +1360,7 @@ struct
 
 end
 
-let load_driver ?log_calls ?on_unknown ~dll ~use_get_function_list =
+let load_driver ?log_calls ?on_unknown ~use_get_function_list dll =
   begin
     match on_unknown with
     | Some f -> Pkcs11_log.set_logging_function f

--- a/src_driver/pkcs11.mli
+++ b/src_driver/pkcs11.mli
@@ -1065,6 +1065,6 @@ exception Cannot_load_module of string * P11_rv.t
 val load_driver:
   ?log_calls:(string * Format.formatter) ->
   ?on_unknown:(string -> unit) ->
-  dll: string ->
   use_get_function_list: [ `Auto | `False | `True ] ->
+  string ->
   (module RAW)

--- a/test/example_digest.ml
+++ b/test/example_digest.ml
@@ -19,10 +19,8 @@ let run ~dll ~slot_id ~pin ~plaintext =
   Pkcs11_log.set_logging_function prerr_endline;
   let driver =
     P11_driver.load_driver
-      ?log_calls:None
-      ?on_unknown:None
-      ~dll
       ~use_get_function_list:`Auto
+      dll
   in
   P11_driver.initialize driver;
   let slot =

--- a/test/example_sign.ml
+++ b/test/example_sign.ml
@@ -47,10 +47,8 @@ let run ~dll ~slot_id ~pin ~key_label ~plaintext =
   Pkcs11_log.set_logging_function prerr_endline;
   let (module S) =
     P11_driver.load_driver
-      ?log_calls:None
-      ?on_unknown:None
-      ~dll
       ~use_get_function_list:`Auto
+      dll
   in
   S.initialize ();
   let slot = match S.get_slot slot_id with

--- a/test/test_p11_load.ml
+++ b/test/test_p11_load.ml
@@ -208,10 +208,8 @@ let test_p11_load =
   let dll = "./_build/src_dll/dllpkcs11_fake.so" in
   let driver =
     P11_driver.load_driver
-      ?log_calls:None
-      ?on_unknown:None
       ~use_get_function_list:`False
-      ~dll
+      dll
   in
   let (module R) = driver in
   R.initialize ();


### PR DESCRIPTION
That way, optional arguments can be erased.

Closes #89