### PR TITLE
Rename use_get_function_list to load_mode

### DIFF
--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -23,6 +23,7 @@ let api =
   ; "P11_key_attributes"
   ; "P11_key_gen_mechanism"
   ; "P11_key_type"
+  ; "P11_load_mode"
   ; "P11_mechanism"
   ; "P11_mechanism_info"
   ; "P11_mechanism_type"

--- a/src/p11.ml
+++ b/src/p11.ml
@@ -36,3 +36,4 @@ module EC_KDF = P11_ec_kdf
 module AES_CTR_params = P11_aes_ctr_params
 module GCM_params = P11_gcm_params
 module AES_key_wrap_params = P11_aes_key_wrap_params
+module Load_mode = P11_load_mode

--- a/src/p11.mli
+++ b/src/p11.mli
@@ -37,3 +37,4 @@ module EC_KDF = P11_ec_kdf
 module AES_CTR_params = P11_aes_ctr_params
 module GCM_params = P11_gcm_params
 module AES_key_wrap_params = P11_aes_key_wrap_params
+module Load_mode = P11_load_mode

--- a/src/p11_load_mode.ml
+++ b/src/p11_load_mode.ml
@@ -1,0 +1,11 @@
+type t =
+  | Auto
+  | Stubs
+  | FFI
+[@@deriving eq,ord,show,yojson]
+
+let auto = Auto
+
+let stubs = Stubs
+
+let ffi = FFI

--- a/src/p11_load_mode.mli
+++ b/src/p11_load_mode.mli
@@ -1,0 +1,20 @@
+(** How the interaction is done with the DLL. *)
+type t =
+  | Auto
+  | Stubs
+  | FFI
+[@@deriving eq,ord,show,yojson]
+
+(** Call directly each symbol using libffi. *)
+val ffi : t
+
+(** Use C stubs to load the DLL using dlopen, and call each symbol through
+    C_GetFunctionList. *)
+val stubs : t
+
+(**
+   Call C_GetFunctionList using libffi.
+   For each symbol, try to access it through the returned function list.
+   Otherwise, call the symbol directly.
+*)
+val auto : t

--- a/src/p11_load_mode.mli
+++ b/src/p11_load_mode.mli
@@ -1,5 +1,5 @@
 (** How the interaction is done with the DLL. *)
-type t =
+type t = private
   | Auto
   | Stubs
   | FFI

--- a/src/pkcs11.mllib
+++ b/src/pkcs11.mllib
@@ -19,6 +19,7 @@ P11_info
 P11_key_attributes
 P11_key_gen_mechanism
 P11_key_type
+P11_load_mode
 P11_mechanism
 P11_mechanism_info
 P11_mechanism_type

--- a/src_cli/pkcs11_cli.ml
+++ b/src_cli/pkcs11_cli.ml
@@ -52,27 +52,27 @@ module Arg = struct
       ~doc: "$(docv)"
       [ "p"; "pin" ]
 
-  let use_get_function_list =
+  let load_mode =
     let open Cmdliner.Arg in
     let auto =
       info
         ~doc: "Try to use C_GetFunctionList, and if it fails, try again without using it."
         ["indirect_or_direct"]
     in
-    let true_ =
+    let stubs =
       info
         ~doc: "Use C_GetFunctionList."
         ["indirect"]
     in
-    let false_ =
+    let ffi =
       info
         ~doc: "Do not use C_GetFunctionList."
         ["direct"]
     in
-    vflag `Auto
-      [ `Auto, auto
-      ; `True, true_
-      ; `False, false_
+    vflag P11.Load_mode.auto
+      [ P11.Load_mode.auto, auto
+      ; P11.Load_mode.stubs, stubs
+      ; P11.Load_mode.ffi, ffi
       ]
 
   let user_type =
@@ -128,8 +128,8 @@ module Term = struct
   let pin =
     Cmdliner.Arg.value Arg.pin
 
-  let use_get_function_list =
-    Cmdliner.Arg.value Arg.use_get_function_list
+  let load_mode =
+    Cmdliner.Arg.value Arg.load_mode
 
   let user_type =
     Cmdliner.Arg.value Arg.user_type

--- a/src_cli/pkcs11_cli.mli
+++ b/src_cli/pkcs11_cli.mli
@@ -26,7 +26,7 @@ module Arg : sig
   (** How to access the PKCS11 DLL. [--direct]: call the function directly.
   [--indirect]: use [C_GetFunctionList]. [--indirect_or_direct] (the default): try
   to use [C_GetFunctionList], and if it fails, try directly. *)
-  val use_get_function_list : [`Auto | `True | `False] Cmdliner.Arg.t
+  val load_mode : P11.Load_mode.t Cmdliner.Arg.t
 
   (** [--user-type]: select user type:
   [CKU_USER] (["user"]) or [CKU_SO] (["so"]) *)
@@ -55,8 +55,8 @@ module Term : sig
   (** Shortcut for [Cmdliner.Arg.value Arg.pin]. *)
   val pin : string option Cmdliner.Term.t
 
-  (** Shortcut for [Cmdliner.Arg.value Arg.use_get_function_list]. *)
-  val use_get_function_list : [`Auto | `True | `False] Cmdliner.Term.t
+  (** Shortcut for [Cmdliner.Arg.value Arg.load_mode]. *)
+  val load_mode : P11.Load_mode.t Cmdliner.Term.t
 
   (** Shortcut for [Cmdliner.Arg.value Arg.user_type]. *)
   val user_type : P11.User_type.t option Cmdliner.Term.t

--- a/src_driver/p11_driver.ml
+++ b/src_driver/p11_driver.ml
@@ -706,8 +706,8 @@ let unwrap_key (module S : S) = S.unwrap_key
 let derive_key (module S : S) = S.derive_key
 let digest (module S : S) = S.digest
 
-let load_driver ?log_calls ?on_unknown ~load_mode dll =
+let load_driver ?log_calls ?on_unknown ?load_mode dll =
   let module Implem =
-    (val (Pkcs11.load_driver ?log_calls ?on_unknown ~load_mode dll) : Pkcs11.RAW)
+    (val (Pkcs11.load_driver ?log_calls ?on_unknown ?load_mode dll) : Pkcs11.RAW)
   in
   (module (Make (Implem)): S)

--- a/src_driver/p11_driver.ml
+++ b/src_driver/p11_driver.ml
@@ -706,8 +706,8 @@ let unwrap_key (module S : S) = S.unwrap_key
 let derive_key (module S : S) = S.derive_key
 let digest (module S : S) = S.digest
 
-let load_driver ?log_calls ?on_unknown ~use_get_function_list dll =
+let load_driver ?log_calls ?on_unknown ~load_mode dll =
   let module Implem =
-    (val (Pkcs11.load_driver ?log_calls ?on_unknown ~use_get_function_list dll) : Pkcs11.RAW)
+    (val (Pkcs11.load_driver ?log_calls ?on_unknown ~load_mode dll) : Pkcs11.RAW)
   in
   (module (Make (Implem)): S)

--- a/src_driver/p11_driver.mli
+++ b/src_driver/p11_driver.mli
@@ -177,6 +177,6 @@ module Make (X: Pkcs11.RAW): S
 val load_driver:
   ?log_calls:(string * Format.formatter) ->
   ?on_unknown:(string -> unit) ->
-  load_mode: P11.Load_mode.t ->
+  ?load_mode: P11.Load_mode.t ->
   string ->
   t

--- a/src_driver/p11_driver.mli
+++ b/src_driver/p11_driver.mli
@@ -177,6 +177,6 @@ module Make (X: Pkcs11.RAW): S
 val load_driver:
   ?log_calls:(string * Format.formatter) ->
   ?on_unknown:(string -> unit) ->
-  use_get_function_list: [ `Auto | `False | `True ] ->
+  load_mode: P11.Load_mode.t ->
   string ->
   t

--- a/src_driver/pkcs11.ml
+++ b/src_driver/pkcs11.ml
@@ -1360,7 +1360,7 @@ struct
 
 end
 
-let load_driver ?log_calls ?on_unknown ~load_mode dll =
+let load_driver ?log_calls ?on_unknown ?(load_mode=P11.Load_mode.auto) dll =
   begin
     match on_unknown with
     | Some f -> Pkcs11_log.set_logging_function f

--- a/src_driver/pkcs11.ml
+++ b/src_driver/pkcs11.ml
@@ -466,43 +466,6 @@ struct
 end
 
 (******************************************************************************)
-(*                           Indirect style bindings                          *)
-(******************************************************************************)
-
-module Indirect (X: CONFIG) : RAW =
-struct
-  let c_GetFunctionList =
-    Foreign.foreign
-      ~from:X.library
-      ~stub:true
-      "C_GetFunctionList"
-      CK.T.c_GetFunctionList
-
-  let function_list =
-    (* WARNING: This code is duplicated in the Make module below.  *)
-    let c_GetFunctionList: unit -> CK_RV.t * ck_function_list =
-      fun () ->
-        let p = allocate_n ~count:1 ((ptr ck_function_list)) in
-        let rv = c_GetFunctionList p in
-        rv, !@ (!@ p)
-    in
-    let rv,fl = c_GetFunctionList () in
-    if rv = CK_RV._CKR_OK
-    then fl
-    else raise (GetFunctionList_Failure (P11_rv.to_string @@ Pkcs11_CK_RV.view rv))
-
-  include Raw(struct
-      let declare name field typ =
-        let f = getf function_list field in
-        match X.log_calls with
-          | None -> f
-          | Some (prefix,fmt) ->
-              log fmt ~header:(prefix ^ ": " ^ name) ~footer:"\n" typ f
-      let c_GetFunctionList = c_GetFunctionList
-    end)
-end
-
-(******************************************************************************)
 (*                            Direct style bindings                           *)
 (******************************************************************************)
 
@@ -517,28 +480,6 @@ struct
       | None -> f
       | Some (prefix,fmt) ->
           log fmt ~header:(prefix ^ ": " ^ name) ~footer:"\n" typ f
-
-  let c_GetFunctionList = declare "C_GetFunctionList" CK.T.c_GetFunctionList
-
-  include Raw(struct
-      let declare
-          (name : string)
-          (_field : (('a -> 'b), (_ck_function_list, [ `Struct ]) Ctypes.structured) Ctypes.field)
-          (typ : ('a -> 'b) Ctypes.fn) = declare name typ
-      let c_GetFunctionList = c_GetFunctionList
-    end)
-end
-
-(******************************************************************************)
-(*                            Local style bindings                           *)
-(******************************************************************************)
-
-module Local (X : sig  end) : RAW =
-struct
-
-
-  let declare : 'a 'b . string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b) = fun name typ ->
-    Foreign.foreign name typ
 
   let c_GetFunctionList = declare "C_GetFunctionList" CK.T.c_GetFunctionList
 

--- a/src_driver/pkcs11.mli
+++ b/src_driver/pkcs11.mli
@@ -1065,6 +1065,6 @@ exception Cannot_load_module of string * P11_rv.t
 val load_driver:
   ?log_calls:(string * Format.formatter) ->
   ?on_unknown:(string -> unit) ->
-  use_get_function_list: [ `Auto | `False | `True ] ->
+  load_mode: P11.Load_mode.t ->
   string ->
   (module RAW)

--- a/src_driver/pkcs11.mli
+++ b/src_driver/pkcs11.mli
@@ -927,11 +927,8 @@ module type CONFIG = sig
   val library : Dl.library
 end
 
-
 (* Used in the reverse bindings generator. *)
 module Fake(X : sig end) : RAW
-
-module Local(X : sig end) : RAW
 
 module type S =
 sig

--- a/src_driver/pkcs11.mli
+++ b/src_driver/pkcs11.mli
@@ -1065,6 +1065,6 @@ exception Cannot_load_module of string * P11_rv.t
 val load_driver:
   ?log_calls:(string * Format.formatter) ->
   ?on_unknown:(string -> unit) ->
-  load_mode: P11.Load_mode.t ->
+  ?load_mode: P11.Load_mode.t ->
   string ->
   (module RAW)

--- a/src_driver/pkcs11_types.ml
+++ b/src_driver/pkcs11_types.ml
@@ -7,11 +7,6 @@ open Ctypes
     indirection through the list of function returned by
     GetFunctionList. *)
 
-(** The GetFunctionList function failed, i.e., returned a return-value
-    different from CKR_OK. This exception can only be triggered in the
-    Indirect mode of our bindings. *)
-exception GetFunctionList_Failure of string
-
 (** CONVENTIONS.
 
     _t is a type variable used to constrain the [Ctypes] representation.  It

--- a/test/example_digest.ml
+++ b/test/example_digest.ml
@@ -19,7 +19,7 @@ let run ~dll ~slot_id ~pin ~plaintext =
   Pkcs11_log.set_logging_function prerr_endline;
   let driver =
     P11_driver.load_driver
-      ~use_get_function_list:`Auto
+      ~load_mode:P11.Load_mode.auto
       dll
   in
   P11_driver.initialize driver;

--- a/test/example_digest.ml
+++ b/test/example_digest.ml
@@ -17,11 +17,7 @@ let print_digest driver session plaintext mechanism =
 
 let run ~dll ~slot_id ~pin ~plaintext =
   Pkcs11_log.set_logging_function prerr_endline;
-  let driver =
-    P11_driver.load_driver
-      ~load_mode:P11.Load_mode.auto
-      dll
-  in
+  let driver = P11_driver.load_driver dll in
   P11_driver.initialize driver;
   let slot =
     match P11_driver.get_slot driver slot_id with

--- a/test/example_sign.ml
+++ b/test/example_sign.ml
@@ -45,11 +45,7 @@ let get_singleton = function
 
 let run ~dll ~slot_id ~pin ~key_label ~plaintext =
   Pkcs11_log.set_logging_function prerr_endline;
-  let (module S) =
-    P11_driver.load_driver
-      ~load_mode:P11.Load_mode.auto
-      dll
-  in
+  let (module S) = P11_driver.load_driver dll in
   S.initialize ();
   let slot = match S.get_slot slot_id with
     | Ok s -> s

--- a/test/example_sign.ml
+++ b/test/example_sign.ml
@@ -47,7 +47,7 @@ let run ~dll ~slot_id ~pin ~key_label ~plaintext =
   Pkcs11_log.set_logging_function prerr_endline;
   let (module S) =
     P11_driver.load_driver
-      ~use_get_function_list:`Auto
+      ~load_mode:P11.Load_mode.auto
       dll
   in
   S.initialize ();

--- a/test/test_p11_load.ml
+++ b/test/test_p11_load.ml
@@ -206,11 +206,7 @@ let test_object driver =
 
 let test_p11_load =
   let dll = "./_build/src_dll/dllpkcs11_fake.so" in
-  let driver =
-    P11_driver.load_driver
-      ~load_mode:P11.Load_mode.auto
-      dll
-  in
+  let driver = P11_driver.load_driver dll in
   let (module R) = driver in
   R.initialize ();
   [ "Driver" >::: test_driver driver

--- a/test/test_p11_load.ml
+++ b/test/test_p11_load.ml
@@ -208,7 +208,7 @@ let test_p11_load =
   let dll = "./_build/src_dll/dllpkcs11_fake.so" in
   let driver =
     P11_driver.load_driver
-      ~use_get_function_list:`False
+      ~load_mode:P11.Load_mode.auto
       dll
   in
   let (module R) = driver in


### PR DESCRIPTION
The `use_get_function_list` parameter (to `load_driver`) gets a name and a module. It describes how interaction with the DLL performs.

Most users can use the default value (`auto`) which just works. If more control is required, the following mapping is used:

| former name | new name |
| - | - |
| false | ffi |
| true | stubs |
| auto | auto |

The `stubs` mode is pretty complex, has global state (in `pkcs11-module.c`) and has the only advantage of being a fallback when `libffi` is not present (which is pretty much never the case), so it'll probably be removed at some point.