### PR TITLE
Deprecate analysis features

### DIFF
--- a/src/p11_attribute.mli
+++ b/src/p11_attribute.mli
@@ -27,8 +27,10 @@ type kind =
    An attribute has kinds [ A; B; C ] if one of the lists returned by [kinds]
    has at least kinds [ A; B; C ]. *)
 val kinds: pack -> kind list list
+[@@deprecated]
 
 (** Return whether [a] has all kinds [k]. *)
 val is : kind list -> pack -> bool
+[@@deprecated]
 
 val type_ : pack -> P11_attribute_type.pack

--- a/src/p11_key_attributes.mli
+++ b/src/p11_key_attributes.mli
@@ -21,3 +21,4 @@ type kind =
     that some other attribute can be given but not necessarily to all
     of the object of this kind. *)
 val possible : kind -> P11.Attribute_types.t
+[@@deprecated]

--- a/src/p11_mechanism.mli
+++ b/src/p11_mechanism.mli
@@ -111,10 +111,12 @@ type kind =
   (** [kinds mechanism] returns the tags for the mechanism
     [mechanism].  *)
 val kinds : t -> kind list
+[@@deprecated]
 
 (** [is kinds t] checks that the mechanism [t] has all the tags in
     the list [kinds].  *)
 val is: kind list -> t -> bool
+[@@deprecated]
 
 (** [key_type t] returns the type of keys associated to the mechanism [t]. *)
 val key_type: t -> P11_key_type.t option


### PR DESCRIPTION
"Kinds" and "key attributes" are not relevant to this binding library, so let's remove them in the next release.