### PR TITLE
Deprecate the "stubs" load mode

### DIFF
--- a/src/p11_load_mode.mli
+++ b/src/p11_load_mode.mli
@@ -11,6 +11,7 @@ val ffi : t
 (** Use C stubs to load the DLL using dlopen, and call each symbol through
     C_GetFunctionList. *)
 val stubs : t
+[@@deprecated]
 
 (**
    Call C_GetFunctionList using libffi.


### PR DESCRIPTION
This mode relies on some C code with globals that is linked into the library. The only advantage of it is that it does not rely on `libffi`, but that library is available virtually everywhere, even in obscure Unix
systems.
    
This load mode will be removed in a future release, and in particular `--indirect` will be removed as well.