### PR TITLE
Encode CKA_ID as hex string in json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+Breaking changes:
+- Encode CKA_ID data as an hex encoded json string. (#101)
+
 v0.15.0 2018-02-19
 ==================
 

--- a/src/p11_attribute.ml
+++ b/src/p11_attribute.ml
@@ -104,7 +104,7 @@ let to_json : type a . a t -> Yojson.Safe.json = fun attribute ->
     | CKA_SUBJECT, param ->
         p_string "CKA_SUBJECT" param
     | CKA_ID, param ->
-        p_string "CKA_ID" param
+        p_data "CKA_ID" param
     | CKA_SENSITIVE, param ->
         p_bool "CKA_SENSITIVE" param
     | CKA_ENCRYPT, param ->
@@ -234,7 +234,7 @@ let pack_of_yojson json : (pack, string) result =
       | "CKA_SUBJECT" ->
           p_string CKA_SUBJECT
       | "CKA_ID" ->
-          p_string CKA_ID
+          p_data CKA_ID
       | "CKA_SENSITIVE" ->
           p_bool CKA_SENSITIVE
       | "CKA_ENCRYPT" ->

--- a/test/test_p11_attribute.ml
+++ b/test/test_p11_attribute.ml
@@ -13,6 +13,9 @@ let pack_to_yojson_suite =
     test
       ~pack:(P11_attribute.Pack (P11_attribute_type.CKA_EC_PARAMS, "\x00"))
       ~expected:(`Assoc [("CKA_EC_PARAMS", `String "0x00")])
+  ; "CKA_ID" >:: test
+      ~pack:(Pack (CKA_ID, "\x00"))
+      ~expected:(`Assoc [("CKA_ID", `String "0x00")])
   ]
 
 let pack_of_yojson_suite =
@@ -29,6 +32,9 @@ let pack_of_yojson_suite =
     test
       ~json:(`Assoc [("CKA_EC_PARAMS", `String "0x00")])
       ~expected:(Ok (P11_attribute.Pack (P11_attribute_type.CKA_EC_PARAMS, "\x00")))
+  ; "CKA_ID" >:: test
+      ~json:(`Assoc [("CKA_ID", `String "0x00")])
+      ~expected:(Ok (Pack (CKA_ID, "\x00")))
   ]
 
 let suite =

--- a/test/test_template.ml
+++ b/test/test_template.ml
@@ -29,10 +29,14 @@ let test_hash_template ctx =
   let rev_template = List.rev template in
   let hash = P11.Template.hash template in
   let hex_hash = Digest.to_hex hash in
-  assert_equal "62dbff83a5b0934c5db0f299576c72de" hex_hash;
+  assert_equal ~cmp:[%eq: string] ~printer:[%show: string]
+    "55aa7ba6c64a5147b8c98e17a8289bb2"
+    hex_hash;
   let rev_hash = P11.Template.hash rev_template in
   let hex_rev_hash = Digest.to_hex rev_hash in
-  assert_equal "62dbff83a5b0934c5db0f299576c72de" hex_rev_hash
+  assert_equal ~cmp:[%eq: string] ~printer:[%show: string]
+    "55aa7ba6c64a5147b8c98e17a8289bb2"
+    hex_rev_hash
 
 let suite =
   "p11_template" >::: [


### PR DESCRIPTION
CKA_ID is associated with an arbitrary byte string, potentially containing non ascii characters leading to invalid json encoding.