### PR TITLE
Implement attribute operations using the repr type

### DIFF
--- a/src/p11_attribute.ml
+++ b/src/p11_attribute.ml
@@ -163,137 +163,31 @@ let compare_types (a,_) (b,_) =
 let compare_types_pack (Pack (a, _)) (Pack (b, _)) =
   P11_attribute_type.compare a b
 
-let compare_bool = [%ord: bool]
 let compare_string = [%ord: string]
-let compare_ulong = [%ord: P11_ulong.t]
 
-let compare (type a) (type b) (a:a t) (b: b t) =
+let compare_not_implemented
+    (P11_attribute_type.NOT_IMPLEMENTED a)
+    (P11_attribute_type.NOT_IMPLEMENTED b)
+    =
+    compare_string a b
+
+let compare_using_repr (type a) (repr : a repr) : a -> a -> int =
+  match repr with
+  | Repr_object_class -> P11_object_class.compare
+  | Repr_bool -> [%ord: bool]
+  | Repr_string -> compare_string
+  | Repr_key_type -> P11_key_type.compare
+  | Repr_not_implemented -> compare_not_implemented
+  | Repr_bigint -> P11_bigint.compare
+  | Repr_ulong -> P11_ulong.compare
+  | Repr_key_gen_mechanism -> P11_key_gen_mechanism.compare
+  | Repr_data -> compare_string
+
+let compare (type a) (type b) ((ta, va):a t) ((tb, vb): b t) =
   let open P11_attribute_type in
-  let c = compare_types a b in
-  if c <> 0 then
-    c
-  else
-    (* This match raises warning 4 in a spurious manner. The first
-       component of the match would be non-exhaustive if we added a
-       new constructor to the the type. The system is not smart
-       enough to detect that the right part (which would become
-       non-exhaustive) is related to the left part. *)
-    match[@ocaml.warning "-4"] a, b with
-      | (CKA_CLASS, a_param), (CKA_CLASS, b_param) ->
-          P11_object_class.compare a_param b_param
-      | (CKA_KEY_TYPE, a_param), (CKA_KEY_TYPE, b_param) ->
-          P11_key_type.compare a_param b_param
-      | (CKA_MODULUS_BITS, a_param), (CKA_MODULUS_BITS, b_param) ->
-          P11_ulong.compare a_param b_param
-      | (CKA_VALUE_LEN, a_param), (CKA_VALUE_LEN, b_param) ->
-          P11_ulong.compare a_param b_param
-      | (CKA_KEY_GEN_MECHANISM, a_param), (CKA_KEY_GEN_MECHANISM, b_param) ->
-          P11_key_gen_mechanism.compare a_param b_param
-      | (CKA_EC_PARAMS, a_param), (CKA_EC_PARAMS, b_param) -> compare_string a_param b_param
-      | (CKA_EC_POINT, a_param), (CKA_EC_POINT, b_param) -> compare_string a_param b_param
-      | (CKA_PUBLIC_EXPONENT, a_param), (CKA_PUBLIC_EXPONENT, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_PRIVATE_EXPONENT, a_param), (CKA_PRIVATE_EXPONENT, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_PRIME_1, a_param), (CKA_PRIME_1, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_PRIME_2, a_param), (CKA_PRIME_2, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_EXPONENT_1, a_param), (CKA_EXPONENT_1, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_EXPONENT_2, a_param), (CKA_EXPONENT_2, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_COEFFICIENT, a_param), (CKA_COEFFICIENT, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_PRIME, a_param), (CKA_PRIME, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_SUBPRIME, a_param), (CKA_SUBPRIME, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_BASE, a_param), (CKA_BASE, b_param) -> P11_bigint.compare a_param b_param
-      | (CKA_MODULUS, a_param), (CKA_MODULUS, b_param) -> P11_bigint.compare a_param b_param
-
-      | (CKA_TOKEN, a_param), (CKA_TOKEN, b_param) -> compare_bool a_param b_param
-      | (CKA_PRIVATE, a_param), (CKA_PRIVATE, b_param) -> compare_bool a_param b_param
-      | (CKA_TRUSTED, a_param), (CKA_TRUSTED, b_param) -> compare_bool a_param b_param
-      | (CKA_SENSITIVE, a_param), (CKA_SENSITIVE, b_param) -> compare_bool a_param b_param
-      | (CKA_ENCRYPT, a_param), (CKA_ENCRYPT, b_param) -> compare_bool a_param b_param
-      | (CKA_DECRYPT, a_param), (CKA_DECRYPT, b_param) -> compare_bool a_param b_param
-      | (CKA_WRAP, a_param), (CKA_WRAP, b_param) -> compare_bool a_param b_param
-      | (CKA_UNWRAP, a_param), (CKA_UNWRAP, b_param) -> compare_bool a_param b_param
-      | (CKA_SIGN, a_param), (CKA_SIGN, b_param) -> compare_bool a_param b_param
-      | (CKA_SIGN_RECOVER, a_param), (CKA_SIGN_RECOVER, b_param) -> compare_bool a_param b_param
-      | (CKA_VERIFY, a_param), (CKA_VERIFY, b_param) -> compare_bool a_param b_param
-      | (CKA_VERIFY_RECOVER, a_param), (CKA_VERIFY_RECOVER, b_param) -> compare_bool a_param b_param
-      | (CKA_DERIVE, a_param), (CKA_DERIVE, b_param) -> compare_bool a_param b_param
-      | (CKA_EXTRACTABLE, a_param), (CKA_EXTRACTABLE, b_param) -> compare_bool a_param b_param
-      | (CKA_LOCAL, a_param), (CKA_LOCAL, b_param) -> compare_bool a_param b_param
-      | (CKA_NEVER_EXTRACTABLE, a_param), (CKA_NEVER_EXTRACTABLE, b_param) -> compare_bool a_param b_param
-      | (CKA_ALWAYS_SENSITIVE, a_param), (CKA_ALWAYS_SENSITIVE, b_param) -> compare_bool a_param b_param
-      | (CKA_MODIFIABLE, a_param), (CKA_MODIFIABLE, b_param) -> compare_bool a_param b_param
-      | (CKA_ALWAYS_AUTHENTICATE, a_param), (CKA_ALWAYS_AUTHENTICATE, b_param) -> compare_bool a_param b_param
-      | (CKA_WRAP_WITH_TRUSTED, a_param), (CKA_WRAP_WITH_TRUSTED, b_param) -> compare_bool a_param b_param
-      | (CKA_LABEL, a_param), (CKA_LABEL, b_param) -> compare_string a_param b_param
-      | (CKA_VALUE, a_param), (CKA_VALUE, b_param) -> compare_string a_param b_param
-      | (CKA_SUBJECT, a_param), (CKA_SUBJECT, b_param) -> compare_string a_param b_param
-      | (CKA_ID, a_param), (CKA_ID, b_param) -> compare_string a_param b_param
-      | (CKA_CHECK_VALUE, NOT_IMPLEMENTED a_param), (CKA_CHECK_VALUE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_START_DATE, NOT_IMPLEMENTED a_param), (CKA_START_DATE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_END_DATE, NOT_IMPLEMENTED a_param), (CKA_END_DATE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_PRIME_BITS, a_param), (CKA_PRIME_BITS,  b_param) -> compare_ulong a_param b_param
-      | (CKA_SUBPRIME_BITS, a_param), (CKA_SUBPRIME_BITS, b_param) -> compare_ulong a_param b_param
-      | (CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED a_param), (CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED a_param), (CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED a_param), (CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED b_param) -> compare_string a_param b_param
-      | (CKA_CS_UNKNOWN a_ul, NOT_IMPLEMENTED a_param),
-        (CKA_CS_UNKNOWN b_ul, NOT_IMPLEMENTED b_param) ->
-          let cmp = Unsigned.ULong.compare a_ul b_ul in
-          if cmp = 0
-          then compare_string a_param b_param
-          else cmp
-        (* Should have been covered by the comparison of attribute types,
-           or by the above cases. *)
-      | (CKA_CLASS, _), _ -> assert false
-      | (CKA_KEY_TYPE, _), _ -> assert false
-      | (CKA_MODULUS_BITS, _), _ -> assert false
-      | (CKA_VALUE_LEN, _), _ -> assert false
-      | (CKA_KEY_GEN_MECHANISM, _), _ -> assert false
-      | (CKA_TOKEN, _), _ -> assert false
-      | (CKA_PRIVATE, _), _ -> assert false
-      | (CKA_TRUSTED, _), _ -> assert false
-      | (CKA_SENSITIVE, _), _ -> assert false
-      | (CKA_ENCRYPT, _), _ -> assert false
-      | (CKA_DECRYPT, _), _ -> assert false
-      | (CKA_WRAP, _), _ -> assert false
-      | (CKA_UNWRAP, _), _ -> assert false
-      | (CKA_SIGN, _), _ -> assert false
-      | (CKA_SIGN_RECOVER, _), _ -> assert false
-      | (CKA_VERIFY, _), _ -> assert false
-      | (CKA_VERIFY_RECOVER, _), _ -> assert false
-      | (CKA_DERIVE, _), _ -> assert false
-      | (CKA_EXTRACTABLE, _), _ -> assert false
-      | (CKA_LOCAL, _), _ -> assert false
-      | (CKA_NEVER_EXTRACTABLE, _), _ -> assert false
-      | (CKA_ALWAYS_SENSITIVE, _), _ -> assert false
-      | (CKA_MODIFIABLE, _), _ -> assert false
-      | (CKA_ALWAYS_AUTHENTICATE, _), _ -> assert false
-      | (CKA_WRAP_WITH_TRUSTED, _), _ -> assert false
-      | (CKA_LABEL, _), _ -> assert false
-      | (CKA_VALUE, _), _ -> assert false
-      | (CKA_SUBJECT, _), _ -> assert false
-      | (CKA_ID, _), _ -> assert false
-      | (CKA_MODULUS, _), _ -> assert false
-      | (CKA_PUBLIC_EXPONENT, _), _ -> assert false
-      | (CKA_PRIVATE_EXPONENT, _), _ -> assert false
-      | (CKA_PRIME_1, _), _ -> assert false
-      | (CKA_PRIME_2, _), _ -> assert false
-      | (CKA_EXPONENT_1, _), _ -> assert false
-      | (CKA_EXPONENT_2, _), _ -> assert false
-      | (CKA_COEFFICIENT, _), _ -> assert false
-      | (CKA_PRIME, _), _ -> assert false
-      | (CKA_SUBPRIME, _), _ -> assert false
-      | (CKA_BASE, _), _ -> assert false
-      | (CKA_EC_PARAMS, _), _ -> assert false
-      | (CKA_EC_POINT, _), _ -> assert false
-      | (CKA_CHECK_VALUE, _), _ -> assert false
-      | (CKA_START_DATE, _), _ -> assert false
-      | (CKA_END_DATE, _), _ -> assert false
-      | (CKA_PRIME_BITS, _), _ -> assert false
-      | (CKA_SUBPRIME_BITS, _), _ -> assert false
-      | (CKA_WRAP_TEMPLATE, _), _ -> assert false
-      | (CKA_UNWRAP_TEMPLATE, _), _ -> assert false
-      | (CKA_ALLOWED_MECHANISMS, _), _ -> assert false
-      | (CKA_CS_UNKNOWN _, _), _ -> assert false
+  match compare' ta tb with
+  | Not_equal r -> r
+  | Equal -> compare_using_repr (repr ta) va vb
 
 let compare_pack (Pack a) (Pack b) = compare a b
 

--- a/src/p11_attribute.ml
+++ b/src/p11_attribute.ml
@@ -2,68 +2,91 @@ type 'a t = 'a P11_attribute_type.t * 'a
 
 type pack = Pack : 'a t -> pack
 
-let to_string_pair =
-  let ulong cka x = cka, Unsigned.ULong.to_string x in
-  let object_class cka cko = cka, P11_object_class.to_string cko in
-  let bool cka x = cka, if x then "CK_TRUE" else "CK_FALSE" in
-  let string cka x = cka, Printf.sprintf "%S" x in
-  let key_type cka ckk = cka, P11_key_type.to_string ckk in
-  let mechanism_type cka x = cka, P11_key_gen_mechanism.to_string x in
-  let bigint cka x = cka, P11_bigint.to_string x in
-  fun (type s) (x : s t) ->
-    let open P11_attribute_type in
-    match x with
-      | CKA_CLASS, x               -> object_class "CKA_CLASS" x
-      | CKA_TOKEN, x               -> bool "CKA_TOKEN" x
-      | CKA_PRIVATE, x             -> bool "CKA_PRIVATE" x
-      | CKA_LABEL, x               -> string "CKA_LABEL" x
-      | CKA_VALUE, x               -> string "CKA_VALUE" x
-      | CKA_TRUSTED, x             -> bool "CKA_TRUSTED" x
-      | CKA_CHECK_VALUE, NOT_IMPLEMENTED x -> string "CKA_CHECK_VALUE" x
-      | CKA_KEY_TYPE, x            -> key_type "CKA_KEY_TYPE" x
-      | CKA_SUBJECT, x             -> string "CKA_SUBJECT" x
-      | CKA_ID, x                  -> string "CKA_ID" x
-      | CKA_SENSITIVE, x           -> bool "CKA_SENSITIVE" x
-      | CKA_ENCRYPT,   x           -> bool "CKA_ENCRYPT" x
-      | CKA_DECRYPT,   x           -> bool "CKA_DECRYPT" x
-      | CKA_WRAP, x                -> bool "CKA_WRAP" x
-      | CKA_UNWRAP, x              -> bool "CKA_UNWRAP" x
-      | CKA_SIGN, x                -> bool "CKA_SIGN" x
-      | CKA_SIGN_RECOVER, x        -> bool "CKA_SIGN_RECOVER" x
-      | CKA_VERIFY, x              -> bool "CKA_VERIFY" x
-      | CKA_VERIFY_RECOVER, x      -> bool "CKA_VERIFY_RECOVER" x
-      | CKA_DERIVE, x              -> bool "CKA_DERIVE" x
-      | CKA_START_DATE, NOT_IMPLEMENTED x -> string "CKA_START_DATE" x
-      | CKA_END_DATE, NOT_IMPLEMENTED x -> string "CKA_END_DATE" x
-      | CKA_MODULUS,  x            -> bigint "CKA_MODULUS" x
-      | CKA_MODULUS_BITS,     x    -> ulong "CKA_MODULUS_BITS" x
-      | CKA_PUBLIC_EXPONENT,  x    -> bigint "CKA_PUBLIC_EXPONENT" x
-      | CKA_PRIVATE_EXPONENT, x    -> bigint "CKA_PRIVATE_EXPONENT" x
-      | CKA_PRIME_1,          x    -> bigint "CKA_PRIME_1" x
-      | CKA_PRIME_2,          x    -> bigint "CKA_PRIME_2" x
-      | CKA_EXPONENT_1,       x    -> bigint "CKA_EXPONENT_1" x
-      | CKA_EXPONENT_2,       x    -> bigint "CKA_EXPONENT_2" x
-      | CKA_COEFFICIENT,      x    -> bigint "CKA_COEFFICIENT" x
-      | CKA_PRIME,            x    -> bigint "CKA_PRIME" x
-      | CKA_SUBPRIME,         x    -> bigint "CKA_SUBPRIME" x
-      | CKA_BASE,             x    -> bigint "CKA_BASE" x
-      | CKA_PRIME_BITS,  x          -> ulong "CKA_PRIME_BITS" x
-      | CKA_SUBPRIME_BITS, x        -> ulong "CKA_SUBPRIME_BITS" x
-      | CKA_VALUE_LEN, x           -> ulong "CKA_VALUE_LEN" x
-      | CKA_EXTRACTABLE, x         -> bool "CKA_EXTRACTABLE" x
-      | CKA_LOCAL,  x              -> bool "CKA_LOCAL" x
-      | CKA_NEVER_EXTRACTABLE, x   -> bool "CKA_NEVER_EXTRACTABLE" x
-      | CKA_ALWAYS_SENSITIVE, x    -> bool "CKA_ALWAYS_SENSITIVE" x
-      | CKA_KEY_GEN_MECHANISM, x   -> mechanism_type "CKA_KEY_GEN_MECHANISM" x
-      | CKA_MODIFIABLE, x          -> bool "CKA_MODIFIABLE" x
-      | CKA_EC_PARAMS, x           -> string "CKA_EC_PARAMS" x
-      | CKA_EC_POINT, x            -> string "CKA_EC_POINT" x
-      | CKA_ALWAYS_AUTHENTICATE, x -> bool "CKA_ALWAYS_AUTHENTICATE" x
-      | CKA_WRAP_WITH_TRUSTED,   x -> bool "CKA_WRAP_WITH_TRUSTED" x
-      | CKA_WRAP_TEMPLATE, NOT_IMPLEMENTED x -> string "CKA_WRAP_TEMPLATE" x
-      | CKA_UNWRAP_TEMPLATE, NOT_IMPLEMENTED x -> string "CKA_UNWRAP_TEMPLATE" x
-      | CKA_ALLOWED_MECHANISMS, NOT_IMPLEMENTED x -> string "CKA_ALLOWED_MECHANISMS" x
-      | CKA_CS_UNKNOWN ul, NOT_IMPLEMENTED x -> string (Unsigned.ULong.to_string ul) x
+type _ repr =
+   | Repr_object_class : P11_object_class.t repr
+   | Repr_bool : bool repr
+   | Repr_string : string repr
+   | Repr_key_type : P11_key_type.t repr
+   | Repr_not_implemented : P11_attribute_type.not_implemented repr
+   | Repr_bigint : P11_bigint.t repr
+   | Repr_ulong : Unsigned.ULong.t repr
+   | Repr_key_gen_mechanism : P11_key_gen_mechanism.t repr
+
+let repr (type a) : a P11_attribute_type.t -> a repr =
+  let open P11_attribute_type in
+  function
+  | CKA_CLASS -> Repr_object_class
+  | CKA_TOKEN -> Repr_bool
+  | CKA_PRIVATE -> Repr_bool
+  | CKA_LABEL -> Repr_string
+  | CKA_VALUE -> Repr_string
+  | CKA_TRUSTED -> Repr_bool
+  | CKA_CHECK_VALUE -> Repr_not_implemented
+  | CKA_KEY_TYPE -> Repr_key_type
+  | CKA_SUBJECT -> Repr_string
+  | CKA_ID -> Repr_string
+  | CKA_SENSITIVE -> Repr_bool
+  | CKA_ENCRYPT -> Repr_bool
+  | CKA_DECRYPT -> Repr_bool
+  | CKA_WRAP -> Repr_bool
+  | CKA_UNWRAP -> Repr_bool
+  | CKA_SIGN -> Repr_bool
+  | CKA_SIGN_RECOVER -> Repr_bool
+  | CKA_VERIFY -> Repr_bool
+  | CKA_VERIFY_RECOVER -> Repr_bool
+  | CKA_DERIVE -> Repr_bool
+  | CKA_START_DATE -> Repr_not_implemented
+  | CKA_END_DATE -> Repr_not_implemented
+  | CKA_MODULUS -> Repr_bigint
+  | CKA_MODULUS_BITS -> Repr_ulong
+  | CKA_PUBLIC_EXPONENT -> Repr_bigint
+  | CKA_PRIVATE_EXPONENT -> Repr_bigint
+  | CKA_PRIME_1 -> Repr_bigint
+  | CKA_PRIME_2 -> Repr_bigint
+  | CKA_EXPONENT_1 -> Repr_bigint
+  | CKA_EXPONENT_2 -> Repr_bigint
+  | CKA_COEFFICIENT -> Repr_bigint
+  | CKA_PRIME -> Repr_bigint
+  | CKA_SUBPRIME -> Repr_bigint
+  | CKA_BASE -> Repr_bigint
+  | CKA_PRIME_BITS -> Repr_ulong
+  | CKA_SUBPRIME_BITS -> Repr_ulong
+  | CKA_VALUE_LEN -> Repr_ulong
+  | CKA_EXTRACTABLE -> Repr_bool
+  | CKA_LOCAL -> Repr_bool
+  | CKA_NEVER_EXTRACTABLE -> Repr_bool
+  | CKA_ALWAYS_SENSITIVE -> Repr_bool
+  | CKA_KEY_GEN_MECHANISM -> Repr_key_gen_mechanism
+  | CKA_MODIFIABLE -> Repr_bool
+  | CKA_EC_PARAMS -> Repr_string
+  | CKA_EC_POINT -> Repr_string
+  | CKA_ALWAYS_AUTHENTICATE -> Repr_bool
+  | CKA_WRAP_WITH_TRUSTED -> Repr_bool
+  | CKA_WRAP_TEMPLATE -> Repr_not_implemented
+  | CKA_UNWRAP_TEMPLATE -> Repr_not_implemented
+  | CKA_ALLOWED_MECHANISMS -> Repr_not_implemented
+  | CKA_CS_UNKNOWN _ -> Repr_not_implemented
+
+let to_string_value (type a) : a repr -> a -> string =
+  let open P11_attribute_type in
+  let bool x = if x then "CK_TRUE" else "CK_FALSE" in
+  let string x = Printf.sprintf "%S" x in
+  let not_implemented (NOT_IMPLEMENTED x) = string x in
+  function
+  | Repr_object_class -> P11_object_class.to_string
+  | Repr_bool -> bool
+  | Repr_string -> string
+  | Repr_key_type -> P11_key_type.to_string
+  | Repr_not_implemented -> not_implemented
+  | Repr_bigint -> P11_bigint.to_string
+  | Repr_ulong -> Unsigned.ULong.to_string
+  | Repr_key_gen_mechanism -> P11_key_gen_mechanism.to_string
+
+let to_string_pair (type s) (x : s t) =
+  let open P11_attribute_type in
+  let cka = to_string (fst x) in
+  let repr = repr (fst x) in
+  (cka, to_string_value repr (snd x))
 
 let to_string x =
   let a, b = to_string_pair x in

--- a/src/p11_attribute.mli
+++ b/src/p11_attribute.mli
@@ -34,3 +34,17 @@ val is : kind list -> pack -> bool
 [@@deprecated]
 
 val type_ : pack -> P11_attribute_type.pack
+
+type _ repr =
+   | Repr_object_class : P11_object_class.t repr
+   | Repr_bool : bool repr
+   | Repr_string : string repr
+   | Repr_key_type : P11_key_type.t repr
+   | Repr_not_implemented : P11_attribute_type.not_implemented repr
+   | Repr_bigint : P11_bigint.t repr
+   | Repr_ulong : Unsigned.ULong.t repr
+   | Repr_key_gen_mechanism : P11_key_gen_mechanism.t repr
+
+(** Return how this attribute type is represented.
+    This is an implementation detail, do not rely on this outside of [pkcs11]. *)
+val repr : 'a P11_attribute_type.t -> 'a repr

--- a/src/p11_attribute.mli
+++ b/src/p11_attribute.mli
@@ -44,6 +44,7 @@ type _ repr =
    | Repr_bigint : P11_bigint.t repr
    | Repr_ulong : Unsigned.ULong.t repr
    | Repr_key_gen_mechanism : P11_key_gen_mechanism.t repr
+   | Repr_data : string repr
 
 (** Return how this attribute type is represented.
     This is an implementation detail, do not rely on this outside of [pkcs11]. *)

--- a/src_driver/pkcs11_CK_ATTRIBUTE.ml
+++ b/src_driver/pkcs11_CK_ATTRIBUTE.ml
@@ -148,6 +148,7 @@ let repr_view (type a) t : a P11_attribute.repr -> a =
   | Repr_object_class -> Pkcs11_CK_OBJECT_CLASS.view (unsafe_get_object_class t)
   | Repr_bool -> unsafe_get_bool t
   | Repr_string -> unsafe_get_string t
+  | Repr_data -> unsafe_get_string t
   | Repr_not_implemented -> NOT_IMPLEMENTED (unsafe_get_string t)
   | Repr_key_type -> Pkcs11_CK_KEY_TYPE.view(unsafe_get_key_type t)
   | Repr_bigint -> P11_bigint.decode (unsafe_get_string t)
@@ -160,6 +161,7 @@ let repr_make (type a) at (param:a) : a P11_attribute.repr -> _ =
   | Repr_object_class -> ulong at (Pkcs11_CK_OBJECT_CLASS.make param)
   | Repr_bool -> boolean at param
   | Repr_string -> string at param
+  | Repr_data -> string at param
   | Repr_not_implemented -> let P11_attribute_type.NOT_IMPLEMENTED s = param in string at s
   | Repr_key_type -> ulong at (Pkcs11_CK_KEY_TYPE.make param)
   | Repr_bigint -> bigint at param

--- a/test/test_p11_attribute.ml
+++ b/test/test_p11_attribute.ml
@@ -1,7 +1,8 @@
 open OUnit2
 
 let pack_to_yojson_suite =
-  let test ~pack ~expected ctxt =
+  let test attr value expected ctxt =
+    let pack = P11_attribute.Pack (attr, value) in
     let actual = P11_attribute.pack_to_yojson pack in
     assert_equal
       ~ctxt
@@ -9,13 +10,47 @@ let pack_to_yojson_suite =
       (Yojson.Safe.to_string expected)
       (Yojson.Safe.to_string actual)
   in
-  [ "CKA_EC_PARAMS" >::
-    test
-      ~pack:(P11_attribute.Pack (P11_attribute_type.CKA_EC_PARAMS, "\x00"))
-      ~expected:(`Assoc [("CKA_EC_PARAMS", `String "0x00")])
+  let assoc k v = `Assoc [(k, `String v)] in
+  [ "CKA_EC_PARAMS" >:: test
+      P11_attribute_type.CKA_EC_PARAMS
+      "\x00"
+      (assoc "CKA_EC_PARAMS" "0x00")
   ; "CKA_ID" >:: test
-      ~pack:(Pack (CKA_ID, "\x00"))
-      ~expected:(`Assoc [("CKA_ID", `String "0x00")])
+      P11_attribute_type.CKA_ID
+      "\x00"
+      (assoc "CKA_ID" "0x00")
+  ; "CKA_CLASS" >:: test
+      P11_attribute_type.CKA_CLASS
+      P11_object_class.CKO_PRIVATE_KEY
+      (assoc "CKA_CLASS" "CKO_PRIVATE_KEY")
+  ; "CKO_TOKEN" >:: test
+      P11_attribute_type.CKA_TOKEN
+      true
+      (assoc "CKA_TOKEN" "CK_TRUE")
+  ; "CKA_LABEL" >:: test
+      P11_attribute_type.CKA_LABEL
+      "label"
+      (assoc "CKA_LABEL" "label")
+  ; "CKA_KEY_TYPE" >:: test
+      P11_attribute_type.CKA_KEY_TYPE
+      P11_key_type.CKK_ARIA
+      (assoc "CKA_KEY_TYPE" "CKK_ARIA")
+  ; "CKA_START_DATE" >:: test
+      P11_attribute_type.CKA_START_DATE
+      (NOT_IMPLEMENTED "ABCD")
+      (assoc "CKA_START_DATE" "0x41424344")
+  ; "CKA_MODULUS" >:: test
+      P11_attribute_type.CKA_MODULUS
+      (P11_bigint.decode "\x01")
+      (assoc "CKA_MODULUS" "0x01")
+  ; "CKA_MODULUS_BITS" >:: test
+      P11_attribute_type.CKA_MODULUS_BITS
+      Unsigned.ULong.zero
+      (assoc "CKA_MODULUS_BITS" "0")
+  ; "CKA_KEY_GEN_MECHANISM" >:: test
+      P11_attribute_type.CKA_KEY_GEN_MECHANISM
+      (P11_key_gen_mechanism.CKM P11_mechanism_type.CKM_ACTI_KEY_GEN)
+      (assoc "CKA_KEY_GEN_MECHANISM" "CKM_ACTI_KEY_GEN")
   ]
 
 let pack_of_yojson_suite =

--- a/test/test_p11_attribute.ml
+++ b/test/test_p11_attribute.ml
@@ -72,8 +72,101 @@ let pack_of_yojson_suite =
       ~expected:(Ok (Pack (CKA_ID, "\x00")))
   ]
 
+let test_compare =
+  let test x y expected ctxt =
+    let got = P11_attribute.compare x y in
+    assert_equal
+      ~ctxt
+      ~cmp:[%eq: int]
+      ~printer:[%show: int]
+      expected
+      got
+  in
+  [ "Class, same" >:: test
+      (CKA_CLASS, P11_object_class.CKO_DATA)
+      (CKA_CLASS, P11_object_class.CKO_DATA)
+      0
+  ; "Class, different" >:: test
+      (CKA_CLASS, P11_object_class.CKO_HW_FEATURE)
+      (CKA_CLASS, P11_object_class.CKO_DATA)
+      1
+  ; "Bool, same" >:: test
+      (CKA_ENCRYPT, true)
+      (CKA_ENCRYPT, true)
+      0
+  ; "Bool, different" >:: test
+      (CKA_ENCRYPT, true)
+      (CKA_ENCRYPT, false)
+      1
+  ; "String, same" >:: test
+      (CKA_LABEL, "label")
+      (CKA_LABEL, "label")
+      0
+  ; "String, different" >:: test
+      (CKA_LABEL, "other")
+      (CKA_LABEL, "label")
+      1
+  ; "Key type, same" >:: test
+      (CKA_KEY_TYPE, P11_key_type.CKK_ACTI)
+      (CKA_KEY_TYPE, P11_key_type.CKK_ACTI)
+      0
+  ; "Key type, different" >:: test
+      (CKA_KEY_TYPE, P11_key_type.CKK_ACTI)
+      (CKA_KEY_TYPE, P11_key_type.CKK_AES)
+      1
+  ; "Not implemented, same" >:: test
+      (CKA_CHECK_VALUE, P11_attribute_type.NOT_IMPLEMENTED "value")
+      (CKA_CHECK_VALUE, P11_attribute_type.NOT_IMPLEMENTED "value")
+      0
+  ; "Not implemented, different" >:: test
+      (CKA_CHECK_VALUE, P11_attribute_type.NOT_IMPLEMENTED "value")
+      (CKA_CHECK_VALUE, P11_attribute_type.NOT_IMPLEMENTED "other")
+      1
+  ; "Bigint, same" >:: test
+      (CKA_MODULUS, P11_bigint.decode "xx")
+      (CKA_MODULUS, P11_bigint.decode "xx")
+      0
+  ; "Bigint, different" >:: test
+      (CKA_MODULUS, P11_bigint.decode "yy")
+      (CKA_MODULUS, P11_bigint.decode "xx")
+      1
+  ; "ULong, same" >:: test
+      (CKA_MODULUS_BITS, Unsigned.ULong.zero)
+      (CKA_MODULUS_BITS, Unsigned.ULong.zero)
+      0
+  ; "ULong, different" >:: test
+      (CKA_MODULUS_BITS, Unsigned.ULong.one)
+      (CKA_MODULUS_BITS, Unsigned.ULong.zero)
+      1
+  ; "Key gen mechanism, same" >:: test
+      (CKA_KEY_GEN_MECHANISM, CKM CKM_AES_KEY_GEN)
+      (CKA_KEY_GEN_MECHANISM, CKM CKM_AES_KEY_GEN)
+      0
+  ; "Key gen mechanism, different" >:: test
+      (CKA_KEY_GEN_MECHANISM, P11_key_gen_mechanism.CK_UNAVAILABLE_INFORMATION)
+      (CKA_KEY_GEN_MECHANISM, CKM CKM_AES_KEY_GEN)
+      1
+  ; "Data, same" >:: test
+      (CKA_ID, "label")
+      (CKA_ID, "label")
+      0
+  ; "Data, different" >:: test
+      (CKA_ID, "other")
+      (CKA_ID, "label")
+      1
+  ; "Different type" >:: test
+      (CKA_MODULUS_BITS, Unsigned.ULong.zero)
+      (CKA_MODULUS, P11_bigint.decode "xx")
+      1
+  ; "Same repr, different type" >:: test
+      (CKA_WRAP, true)
+      (CKA_ENCRYPT, true)
+      1
+  ]
+
 let suite =
   "P11_attribute" >:::
   [ "pack_of_yojson" >::: pack_of_yojson_suite
   ; "pack_to_yojson" >::: pack_to_yojson_suite
+  ; "compare" >::: test_compare
   ]


### PR DESCRIPTION
There was a `repr` type in `CK_ATTRIBUTE` used for internal operations. It turns out that it's pretty useful in `P11_attribute` as well.

The idea is to do all operations in two steps:
- get the `repr` associated to a given attribute type (is it represented using an unsigned long? an ASCII string? a string containing hex data?)
- do the actual thing based on the `repr`.

This is a big simplification because pattern matching is only as wide as the `repr` type, not as `P11_attribute_type.t`.