### PR TITLE
Fix hex data parsing on invalid JSON strings

### DIFF
--- a/src/p11_hex_data.ml
+++ b/src/p11_hex_data.ml
@@ -30,17 +30,21 @@ let of_yojson =
     Error ("P11_hex_data: " ^ msg)
   in
   function
-    | `String s when s.[0] = '0' && s.[1] = 'x' ->
-        let data = Str.string_after s 2 in
-        begin
-          try
-            String.iter (function
-                | '0'..'9' | 'a'..'f' | 'A'..'F' -> ()
-                | _ -> raise Invalid_hex
-              ) data;
-            Ok (Hex.to_string @@ `Hex data)
-          with Invalid_hex ->
-            err "not valid hex-encoded data"
-        end
-    | `String _ -> err "string does not start with \"0x\""
-    | _ -> err "not a string"
+  | `String s when String.length s < 2 ->
+    err "string does not start with \"0x\""
+  | `String s when s.[0] = '0' && s.[1] = 'x' ->
+    let data = Str.string_after s 2 in
+    begin
+      try
+        String.iter (function
+            | '0'..'9' | 'a'..'f' | 'A'..'F' -> ()
+            | _ -> raise Invalid_hex
+          ) data;
+        Ok (Hex.to_string @@ `Hex data)
+      with
+      | Invalid_hex
+      | Invalid_argument _ ->
+        err "not valid hex-encoded data"
+    end
+  | `String _ -> err "string does not start with \"0x\""
+  | _ -> err "not a string"

--- a/test/test_p11_hex_data.ml
+++ b/test/test_p11_hex_data.ml
@@ -1,0 +1,42 @@
+open OUnit2
+
+let test_of_yojson =
+  let test ~data ~expected ctxt = 
+    let actual = P11_hex_data.of_yojson data in
+    assert_equal
+      ~cmp:[%eq: (string, string) result]
+      ~printer:[%show: (string, string) result]
+      expected
+      actual
+  in
+  "of_yojson" >:::
+  [ "not a string" >::
+    test
+      ~data:`Null
+      ~expected:(Error "P11_hex_data: not a string")
+  ; "empty" >::
+    test
+      ~data:(`String "")
+      ~expected:(Error "P11_hex_data: string does not start with \"0x\"")
+  ; "doesn't start with 0x" >::
+    test
+      ~data:(`String "00")
+      ~expected:(Error "P11_hex_data: string does not start with \"0x\"")
+  ; "odd" >::
+    test
+      ~data:(`String "0x0")
+      ~expected:(Error "P11_hex_data: not valid hex-encoded data")
+  ; "non-hex characters" >::
+    test
+      ~data:(`String "0x0g")
+      ~expected:(Error "P11_hex_data: not valid hex-encoded data")
+  ; "one byte" >::
+    test
+      ~data:(`String "0x00")
+      ~expected:(Ok "\x00")
+  ]
+
+let suite =
+  "P11_hex_data" >:::
+  [ test_of_yojson
+  ]

--- a/test/test_suite.ml
+++ b/test/test_suite.ml
@@ -2,15 +2,16 @@ open OUnit2
 
 let suite =
   "Pkcs11" >:::
-  [ Test_bigint.suite
+  [ Test_p11_aes_ctr_params.suite
+  ; Test_p11_aes_key_wrap.suite
   ; Test_p11_attribute.suite
   ; Test_p11_attribute_type.suite
   ; Test_p11_attribute_types.suite
-  ; Test_template.suite
-  ; Test_p11_aes_ctr_params.suite
   ; Test_p11_gcm_params.suite
+  ; Test_p11_hex_data.suite
   ; Test_p11_mechanism.suite
-  ; Test_p11_aes_key_wrap.suite
+  ; Test_template.suite
+  ; Test_bigint.suite
   ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
This adds test for `P11_hex_data.of_yojson` and avoids exceptions for
the following cases:

* Empty strings (Invalid argument: index out of bounds)
* Odd number of hex digits (Invalid_argument "hex conversion:
  invalid hex string")