### PR TITLE
Test get_attribute_optimized

### DIFF
--- a/driver/pkcs11_CK_FLAGS.mli
+++ b/driver/pkcs11_CK_FLAGS.mli
@@ -65,7 +65,7 @@ val _CKF_EXCLUDE_CHALLENGE : t
 val _CKF_EXCLUDE_PIN : t
 val _CKF_USER_FRIENDLY_OTP : t
 
-val to_json : ?pretty:(t -> string) -> t -> Yojson.Safe.json
+val to_json : ?pretty:(t -> string) -> t -> Yojson.Safe.t
 
 val to_string : t -> string
 

--- a/lib/p11_attribute.ml
+++ b/lib/p11_attribute.ml
@@ -99,7 +99,7 @@ let to_string x =
 
 (* Note: it is important for [Template.to_json] and [Template.of_json]
    that all attributes are represented using [`Assoc]. *)
-let to_json : type a . a t -> Yojson.Safe.json = fun attribute ->
+let to_json : type a . a t -> Yojson.Safe.t = fun attribute ->
   let key_json = P11_attribute_type.to_string (fst attribute) in
   let data = P11_hex_data.to_yojson in
   let value_json =
@@ -116,7 +116,7 @@ let to_json : type a . a t -> Yojson.Safe.json = fun attribute ->
   in
   `Assoc [(key_json, value_json)]
 
-let of_yojson_repr (type a) (repr : a repr) : Yojson.Safe.json -> (a, string) result =
+let of_yojson_repr (type a) (repr : a repr) : Yojson.Safe.t -> (a, string) result =
   let (>>=) = Ppx_deriving_yojson_runtime.(>>=) in
   let bool_of_yojson = function
     | `Bool b -> Ok b

--- a/lib/p11_attribute.mli
+++ b/lib/p11_attribute.mli
@@ -6,7 +6,7 @@ val to_string : 'a t -> string
 
 val to_string_pair : 'a t -> string * string
 
-val to_json : 'a t -> Yojson.Safe.json
+val to_json : 'a t -> Yojson.Safe.t
 
 val compare_types: 'a t -> 'b t -> int
 val compare_types_pack: pack -> pack -> int

--- a/lib/p11_attribute_type.mli
+++ b/lib/p11_attribute_type.mli
@@ -173,7 +173,7 @@ val of_string : string -> pack
 
 val to_string : 'a t -> string
 
-val pack_to_json : pack -> Yojson.Safe.json
+val pack_to_json : pack -> Yojson.Safe.t
 
 val elements: pack list
 

--- a/lib/p11_flags.ml
+++ b/lib/p11_flags.ml
@@ -258,7 +258,7 @@ let to_pretty_string domain flags =
     | f -> String.concat " | " f
 
 type has_value =
-  { value : Yojson.Safe.json
+  { value : Yojson.Safe.t
   ; string : string
   }
 [@@deriving of_yojson]

--- a/lib/p11_flags.mli
+++ b/lib/p11_flags.mli
@@ -82,7 +82,7 @@ val to_pretty_string : domain -> t -> string
 
 val to_pretty_strings : domain -> t -> string list
 
-val to_json : ?pretty:(t -> string) -> t -> Yojson.Safe.json
+val to_json : ?pretty:(t -> string) -> t -> Yojson.Safe.t
 
 val split : domain -> t -> t list * t
 

--- a/lib/p11_helpers.mli
+++ b/lib/p11_helpers.mli
@@ -13,7 +13,7 @@ val strings_of_record:
 val of_json_string :
   typename:string ->
   (string -> 'a) ->
-  Yojson.Safe.json ->
+  Yojson.Safe.t ->
   ('a, string) Result.result
 
 (** Remove trailing zeros and spaces, and quote the result.*)

--- a/lib/p11_template.ml
+++ b/lib/p11_template.ml
@@ -1,7 +1,7 @@
 type t = P11_attribute.pack list
 [@@deriving eq,ord,show]
 
-let to_yojson template :Yojson.Safe.json =
+let to_yojson template :Yojson.Safe.t =
   let attributes = List.map (fun (P11_attribute.Pack x) -> P11_attribute.to_json x) template in
   let flatten_attribute = function
     | `Assoc l -> l

--- a/pkcs11.opam
+++ b/pkcs11.opam
@@ -17,7 +17,7 @@ depends: [
   "hex" { >= "1.0.0" }
   "integers"
   "ppx_deriving" { >= "4.0" }
-  "ppx_deriving_yojson" { >= "3.0" }
+  "ppx_deriving_yojson" { >= "3.4" }
   "ppx_variants_conv"
   "zarith"
   "ocaml" {>= "4.04.0"}

--- a/test/driver/test_driver.ml
+++ b/test/driver/test_driver.ml
@@ -12,6 +12,7 @@ let suite =
       ; Test_ck_attribute.suite
       ; Test_ck_aes_ctr_params.suite
       ; Test_ck_gcm_params.suite
+      ; Test_p11_driver.suite
       ]
     ]
 

--- a/test/driver/test_p11_driver.ml
+++ b/test/driver/test_p11_driver.ml
@@ -1,0 +1,145 @@
+open OUnit2
+
+type get_attribute_value_params =
+  ( P11.Session_handle.t
+  * P11.Object_handle.t
+  * P11.Attribute_types.t
+  )
+  [@@deriving eq,show]
+
+module type Mock_driver_params = sig
+  val c_GetAttributeValue :
+    Pkcs11.CK_SESSION_HANDLE.t ->
+    Pkcs11.CK_OBJECT_HANDLE.t ->
+    Pkcs11.CK_ATTRIBUTE.t Ctypes.ptr ->
+    Pkcs11.CK_ULONG.t ->
+    Pkcs11.CK_RV.t
+end
+
+module type Mock_driver_raw = sig
+  include Pkcs11.RAW
+
+  val get_attribute_value_calls : get_attribute_value_params list ref
+end
+
+module Mock_driver_raw (M: Mock_driver_params) : Mock_driver_raw = struct
+  include Pkcs11.Fake()
+
+  let get_attribute_value_calls = ref []
+
+  let c_GetAttributeValue session_handle object_handle template count =
+    let attributes =
+      let num_items = Unsigned.ULong.to_int count in
+      Pkcs11.Template.to_list (Ctypes.CArray.from_ptr template num_items)
+      |> List.map Pkcs11.CK_ATTRIBUTE.get_type
+      |> List.map Pkcs11.CK_ATTRIBUTE_TYPE.view
+    in
+    get_attribute_value_calls := (session_handle, object_handle, attributes) :: !get_attribute_value_calls;
+    M.c_GetAttributeValue session_handle object_handle template count
+end
+
+module type Mock_driver = sig
+  include P11_driver.S
+
+  val get_attribute_value_calls : get_attribute_value_params list ref
+end
+
+module Mock_driver (M: Mock_driver_params) = struct
+  module MDR : Mock_driver_raw = Mock_driver_raw(M)
+  include P11_driver.Make(MDR)
+
+  let get_attribute_value_calls = MDR.get_attribute_value_calls
+end
+
+let mock_driver (module M : Mock_driver_params) () =
+  (module (Mock_driver(M)) : Mock_driver)
+
+module Fixtures = struct
+  let session_handle = Unsigned.ULong.zero
+  let object_handle = Unsigned.ULong.zero
+end
+
+let test_get_attribute_value_optimized =
+  let open Fixtures in
+  let test ~attributes ~f ~expected_calls ctxt =
+    let params = (module struct let c_GetAttributeValue = f end : Mock_driver_params) in
+    let driver = mock_driver params () in
+    let (module Driver : Mock_driver) = driver in
+    let `Optimized get = P11_driver.get_attribute_value_optimized (module (val driver)) attributes in
+    (* Get the values twice to trigger optimization behaviour *)
+    let _ = get session_handle object_handle in
+    let _ = get session_handle object_handle in
+    let actual_calls = List.rev !Driver.get_attribute_value_calls in
+    assert_equal
+      ~ctxt
+      ~cmp:[%eq: get_attribute_value_params list]
+      ~printer:[%show: get_attribute_value_params list]
+      expected_calls
+      actual_calls
+  in
+  "get_attribute_value_optimized" >:::
+  [ "Always failing implies single gets" >::
+    test
+      ~attributes:P11.Attribute_type.[Pack CKA_WRAP; Pack CKA_UNWRAP]
+      ~f:(fun _ _ _ _ -> Pkcs11.CK_RV.make P11.RV.CKR_GENERAL_ERROR)
+      ~expected_calls:
+        (* The first time, a group attempt will be made, and then we fall back to single elements *)
+        [ ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_WRAP; Pack CKA_UNWRAP]
+          )
+        ; ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_WRAP]
+          )
+        ; ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_UNWRAP]
+          )
+        (* The second time, we will have marked both elements as bad, so we query an empty group
+           and fall back to single elements. *)
+        ; ( session_handle
+          , object_handle
+          , []
+          )
+        ; ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_WRAP]
+          )
+        ; ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_UNWRAP]
+          )
+        ]
+  ; "Initial success implies bulk gets" >::
+    test
+      ~attributes:P11.Attribute_type.[Pack CKA_WRAP; Pack CKA_UNWRAP]
+      ~f:(fun _ _ _ _ -> Pkcs11.CK_RV.make P11.RV.CKR_OK)
+      ~expected_calls:
+        (* The first time, since the request succeeds it is made twice (once with memory allocated
+           and once without) see p11_driver.ml for the code that does this. *)
+        [ ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_WRAP; Pack CKA_UNWRAP]
+          )
+        ; ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_WRAP; Pack CKA_UNWRAP]
+          )
+        (* The same thing happens the second time as both are marked as good. *)
+        ; ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_WRAP; Pack CKA_UNWRAP]
+          )
+        ; ( session_handle
+          , object_handle
+          , P11.Attribute_type.[Pack CKA_WRAP; Pack CKA_UNWRAP]
+          )
+        ]
+  ]
+
+
+let suite =
+  "P11_driver" >:::
+  [ test_get_attribute_value_optimized
+  ]

--- a/test/driver/test_p11_driver.mli
+++ b/test/driver/test_p11_driver.mli
@@ -1,0 +1,1 @@
+val suite : OUnit2.test


### PR DESCRIPTION
While I was investigating the slow query behaviour for some HSMs, I added some characterization tests to check the behaviour of the `get_attribute_optimized` function.

Since these are probably generally useful, particularly if we want to change the behaviour in the future, I think we should merge them in.