### PR TITLE
Add support for NSS to the PKCS#11 Driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,13 @@ env:
     - OCAML_VERSION=4.07 PACKAGE=pkcs11-rev
     - OCAML_VERSION=4.07 PACKAGE=pkcs11-driver
     - OCAML_VERSION=4.07 DISTRO=debian-stable
+    - OCAML_VERSION=4.08
+    - OCAML_VERSION=4.08 PACKAGE=pkcs11-cli
+    - OCAML_VERSION=4.08 PACKAGE=pkcs11-rev
+    - OCAML_VERSION=4.08 PACKAGE=pkcs11-driver
+    - OCAML_VERSION=4.08 DISTRO=debian-stable
+    - OCAML_VERSION=4.09
+    - OCAML_VERSION=4.09 PACKAGE=pkcs11-cli
+    - OCAML_VERSION=4.09 PACKAGE=pkcs11-rev
+    - OCAML_VERSION=4.09 PACKAGE=pkcs11-driver
+    - OCAML_VERSION=4.09 DISTRO=debian-stable

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+Unreleased
+==========
+
+## Additions
+
+- Add a new `initialize_nss` function to `pkcs11-driver` to perform a C_Initialize call with the extra parameters that NSS requires (see https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/PKCS11/Module_Specs for more information)
+
+## Changes
+
+- (Breaking) Rename `P11_driver.Make` to `P11_driver.Wrap_low_level_bindings`
+- (Breaking) Rename `Pkcs11.RAW` to `Pkcs11.LOW_LEVEL_BINDINGS`
+- (Breaking) Rename `Pkcs11.S` to `Pkcs11.LOW_LEVEL_WRAPPER`
+- (Breaking) Rename `Pkcs11.Make` to `Pkcs11.Wrap_low_level_bindings`
+
 v0.18.0
 =======
 

--- a/driver/dune
+++ b/driver/dune
@@ -6,6 +6,7 @@
     pkcs11
     pkcs11f
     pkcs11t
+    pkcs11nss
   )
   (libraries
     ctypes.foreign 

--- a/driver/p11_driver.ml
+++ b/driver/p11_driver.ml
@@ -11,6 +11,7 @@ let () =
 
 module type S = sig
   val initialize : unit -> unit
+  val initialize_nss : params: Pkcs11.Nss_initialize_arg.u -> unit
   val finalize : unit -> unit
   val get_info : unit -> Info.t
   val get_slot : Slot.t -> (Slot_id.t, string) result
@@ -138,7 +139,12 @@ module Wrap_low_level_bindings (X: Pkcs11.LOW_LEVEL_BINDINGS) = struct
     else raise (CKR rv)
 
   let initialize : unit -> unit t = fun () ->
-    let rv = c_Initialize () in
+    let rv = c_Initialize None in
+    check_ckr_unit rv
+
+  let initialize_nss : params : string -> unit t = fun ~params ->
+    let args = Pkcs11.Nss_initialize_arg.make params in
+    let rv = c_Initialize (Some args) in
     check_ckr_unit rv
 
   let finalize : unit -> unit t = fun () ->
@@ -649,6 +655,7 @@ end
 type t = (module S)
 
 let initialize (module S : S) = S.initialize ()
+let initialize_nss (module S : S) = S.initialize_nss
 let finalize (module S : S) = S.finalize ()
 let get_info (module S : S) = S.get_info ()
 let get_slot (module S : S) = S.get_slot

--- a/driver/p11_driver.mli
+++ b/driver/p11_driver.mli
@@ -10,6 +10,7 @@ exception CKR of RV.t
     handled automatically. *)
 module type S = sig
   val initialize : unit -> unit
+  val initialize_nss : params: Pkcs11.Nss_initialize_arg.u -> unit
   val finalize : unit -> unit
   val get_info : unit -> Info.t
   val get_slot: Slot.t -> (Slot_id.t, string) result
@@ -119,6 +120,11 @@ end
 type t = (module S)
 
 val initialize : t -> unit
+
+(** Perform a c_Initialize call with NSS-style initialization parameters as described
+    at https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/PKCS11/Module_Specs *)
+val initialize_nss : t -> params: Pkcs11.Nss_initialize_arg.u -> unit
+
 val finalize : t -> unit
 val get_info : t -> Info.t
 val get_slot: t -> Slot.t -> (Slot_id.t, string) result

--- a/driver/pkcs11.ml
+++ b/driver/pkcs11.ml
@@ -584,7 +584,7 @@ end
 (******************************************************************************)
 
 module type LOW_LEVEL_WRAPPER = sig
-  val c_Initialize : unit -> CK_RV.t
+  val c_Initialize : Nss_initialize_arg.t option -> CK_RV.t
   val c_Finalize : unit -> CK_RV.t
   val c_GetInfo : unit -> CK_RV.t * P11_info.t
   (* 03/24/2015: At the moment, we do not need to use GetFunctionList
@@ -714,9 +714,15 @@ module Wrap_low_level_bindings (F : LOW_LEVEL_BINDINGS) : LOW_LEVEL_WRAPPER = st
     let ulong = n |> Unsigned.ULong.of_int in
     ptr_from_string s, ulong
 
-  let c_Initialize : unit -> CK_RV.t =
+  let c_Initialize : Nss_initialize_arg.t option -> CK_RV.t =
     let f = F.c_Initialize in
-    fun () -> f (Ctypes.null)
+    fun args ->
+      let args_ptr =
+        match args with
+        | Some a -> Ctypes.to_voidp (Ctypes.addr a)
+        | None -> Ctypes.null
+      in
+      f args_ptr
 
   let c_Finalize : unit -> CK_RV.t =
     let f = F.c_Finalize in

--- a/driver/pkcs11.mli
+++ b/driver/pkcs11.mli
@@ -61,6 +61,19 @@ module Initialize_arg : sig
   val t :  t Ctypes.typ
 end
 
+module Nss_initialize_arg : sig
+  type _ck_nss_c_initialize_args
+  type t = _ck_nss_c_initialize_args Ctypes.structure
+  val flags : (CK_FLAGS.t, t) Ctypes.field
+  val t :  t Ctypes.typ
+
+  (** Only support setting LibraryParameters from the uninitialized type. The format for
+      these strings is defined in the Softtoken Specific Parameters section of
+      https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/PKCS11/Module_Specs *)
+  type u = string
+  val make : u -> t
+end
+
 type _ck_function_list
 type ck_function_list = _ck_function_list Ctypes.structure
 val ck_function_list : ck_function_list Ctypes.typ
@@ -76,7 +89,7 @@ module CK :
   sig
     module T :
       sig
-        val c_Initialize : (unit Ctypes.ptr-> CK_RV.t) Ctypes.fn
+        val c_Initialize : (unit Ctypes.ptr -> CK_RV.t) Ctypes.fn
         val c_Finalize : (unit Ctypes.ptr -> CK_RV.t) Ctypes.fn
         val c_GetInfo : (CK_INFO.t Ctypes.ptr -> CK_RV.t) Ctypes.fn
         val c_GetFunctionList :
@@ -941,7 +954,7 @@ module Fake(X : sig end) : LOW_LEVEL_BINDINGS
     functions will allocate and initialize the structures as appropriate so the caller does not
     have to. *)
 module type LOW_LEVEL_WRAPPER = sig
-  val c_Initialize : unit -> CK_RV.t
+  val c_Initialize : Nss_initialize_arg.t option -> CK_RV.t
   val c_Finalize : unit -> CK_RV.t
   val c_GetInfo : unit -> CK_RV.t * P11_info.t
   (* val c_GetFunctionList : unit -> CK_RV.t * CK_FUNCTION_LIST.t *)

--- a/driver/pkcs11_types.ml
+++ b/driver/pkcs11_types.ml
@@ -122,6 +122,35 @@ module Initialize_arg = struct
   let () = seal t
 end
 
+module Nss_initialize_arg = struct
+  let mutex = void
+  type _ck_nss_c_initialize_args
+  type t = _ck_nss_c_initialize_args structure
+  let t : t typ = structure "CK_NSS_C_INITIALIZE_ARGS"
+  let (-:) ty label = Ctypes_helpers.smart_field t label ty
+  let f typ = Foreign.funptr_opt (typ @-> returning ck_rv)
+  let createMutex = f (ptr (ptr mutex)) -: "CreateMutex"
+  let destroyMutex = f (ptr mutex) -: "DestroyMutex"
+  let lockMutex = f (ptr mutex) -: "LockMutex"
+  let unlockMutex = f (ptr mutex) -: "UnlockMutex"
+  let flags = ck_flags -: "flags"
+  let libraryParameters = Ctypes.string_opt -: "LibraryParameters"
+  let pReserved = ptr void -: "pReserved"
+  let () = seal t
+
+  type u = string
+  let make (params : u) =
+    let t = Ctypes.make t in
+    Ctypes.setf t createMutex None;
+    Ctypes.setf t destroyMutex None;
+    Ctypes.setf t lockMutex None;
+    Ctypes.setf t unlockMutex None;
+    Ctypes.setf t flags Pkcs11_CK_FLAGS._CKF_OS_LOCKING_OK;
+    Ctypes.setf t libraryParameters (Some params);
+    Ctypes.setf t pReserved Ctypes.null;
+    t
+end
+
 (******************************************************************************)
 (*                                  Functions                                 *)
 (******************************************************************************)

--- a/include/pkcs11.h
+++ b/include/pkcs11.h
@@ -241,6 +241,20 @@ extern "C" {
  * function prototypes. */
 #include "pkcs11f.h"
 
+/* CK_NSS_C_INITIALIZE_ARGS provides the optional arguments to
+ * the modified C_Initialize used by NSS */
+ typedef struct CK_NSS_C_INITIALIZE_ARGS {
+  CK_CREATEMUTEX CreateMutex;
+  CK_DESTROYMUTEX DestroyMutex;
+  CK_LOCKMUTEX LockMutex;
+  CK_UNLOCKMUTEX UnlockMutex;
+  CK_FLAGS flags;
+  CK_VOID_PTR LibraryParameters;
+  CK_VOID_PTR pReserved;
+} CK_NSS_C_INITIALIZE_ARGS;
+
+typedef CK_NSS_C_INITIALIZE_ARGS CK_PTR CK_NSS_C_INITIALIZE_ARGS_PTR;
+
 #undef CK_NEED_ARG_LIST
 #undef CK_PKCS11_FUNCTION_INFO
 

--- a/include/pkcs11nss.h
+++ b/include/pkcs11nss.h
@@ -1,0 +1,16 @@
+/* This file includes extra definitions required to use the NSS library that
+ * are not in the PKCS#11 standard includes. */
+
+/* CK_NSS_C_INITIALIZE_ARGS provides the optional arguments to
+ * the modified C_Initialize used by NSS */
+ typedef struct CK_NSS_C_INITIALIZE_ARGS {
+  CK_CREATEMUTEX CreateMutex;
+  CK_DESTROYMUTEX DestroyMutex;
+  CK_LOCKMUTEX LockMutex;
+  CK_UNLOCKMUTEX UnlockMutex;
+  CK_FLAGS flags;
+  CK_VOID_PTR LibraryParameters;
+  CK_VOID_PTR pReserved;
+} CK_NSS_C_INITIALIZE_ARGS;
+
+typedef CK_NSS_C_INITIALIZE_ARGS CK_PTR CK_NSS_C_INITIALIZE_ARGS_PTR;


### PR DESCRIPTION
(Marking this PR as WIP unitl #117 is merged)

This PR adds support for the Network Security Services (NSS) PKCS#11 implementation when using the `pkcs11-driver` package.

The key difference is in the call to `C_Initialize`, for which NSS requires a different parameter set than the PKCS#11 spec (documented [here](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/PKCS11/Module_Specs)).

I have added a new `initialize_nss` function at the top level which can be used by consumers to trigger this new function.

I have tried to keep the implementation minimal, but would be open to changing the design. The main alternative I could think of would be for the existing `initialize` function to take an `Nss_initialize_args.u option` instead of `unit`, but I decided against that to make it even clearer when the arguments would be used.