### PR TITLE
Fixes to make the library work with macos.

### DIFF
--- a/pkcs11-driver.opam
+++ b/pkcs11-driver.opam
@@ -27,7 +27,6 @@ conflicts: [
   "ctypes" { < "0.12.0" }
 ]
 tags: ["org:cryptosense"]
-available: [os != "macos"]
 synopsis: "Bindings to the PKCS#11 cryptographic API"
 description: """
 This library contains ctypes bindings to the PKCS#11 API.

--- a/pkcs11.opam
+++ b/pkcs11.opam
@@ -24,7 +24,6 @@ depends: [
   "ounit" {with-test}
 ]
 tags: ["org:cryptosense"]
-available: [os != "macos"]
 synopsis: "PKCS#11 OCaml types"
 description: """
 This library contains type definitions for the PKCS#11 API.


### PR DESCRIPTION
3 of the 4 packages actually work with macOS. There's no need to make them unavailable on macOS